### PR TITLE
Force every repayment to be a repay and process outstanding

### DIFF
--- a/src/app/[locale]/borrower/market/[address]/hooks/useRepay.ts
+++ b/src/app/[locale]/borrower/market/[address]/hooks/useRepay.ts
@@ -44,12 +44,11 @@ export const useRepay = (
       const repay = async () => {
         const maxBatches =
           marketAccount.market.unpaidWithdrawalBatchExpiries.length
-        const tx = await (processUnpaidWithdrawalsIfAny && maxBatches > 0
-          ? marketAccount.market.repayAndProcessUnpaidWithdrawalBatches(
-              amount,
-              maxBatches,
-            )
-          : marketAccount.repay(amount.raw))
+        const tx =
+          await marketAccount.market.repayAndProcessUnpaidWithdrawalBatches(
+            amount,
+            maxBatches,
+          )
 
         if (!safeConnected) setTxHash(tx.hash)
 


### PR DESCRIPTION
Make every repay through the UI be a repay and process of the outstanding batches

In the case where there's nothing around, it won't be meaningfully more expensive. If there is, it'll only perform repayments of as many batches as there's newly injected liquidity available to handle.