### PR TITLE
wild429's

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -69,7 +69,7 @@ export default async function RootLayout({
                   locale={locale}
                   resources={resources}
                 >
-                  {/* <PollingRegistration /> */}
+                  <PollingRegistration />
                   <ThemeRegistry>
                     <Box sx={BackgroundContainer} />
                     <Box position="relative" zIndex="1">

--- a/src/components/PollingRegistration/index.tsx
+++ b/src/components/PollingRegistration/index.tsx
@@ -1,38 +1,38 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import { useDispatch } from "react-redux"
 import { useAccount } from "wagmi"
 
-// import { POLLING_INTERVAL } from "@/config/polling"
-// import { SubgraphClient } from "@/config/subgraph"
-// import { usePolling } from "@/hooks/usePolling"
-// import { clear } from "@/store/slices/notificationsSlice/notificationsSlice"
+import { POLLING_INTERVAL } from "@/config/polling"
+import { SubgraphClient } from "@/config/subgraph"
+import { usePolling } from "@/hooks/usePolling"
+import { clear } from "@/store/slices/notificationsSlice/notificationsSlice"
 
-// import { useAPRChanges } from "./hooks/Borrower/useAPRChanges"
-// import { useBorrowerMarketIds } from "./hooks/Borrower/useBorrowerMarketIds"
-// import { useBorrowerRegistrationChanges } from "./hooks/Borrower/useBorrowerRegistrationChanges"
-// import { useBorrows } from "./hooks/Borrower/useBorrows"
-// import { useCapacityChanges } from "./hooks/Borrower/useCapacityChanges"
-// import { useDebtRepaids } from "./hooks/Borrower/useDebtRepaids"
-// import { useDepositeds } from "./hooks/Borrower/useDepositeds"
-// import { useLenderAuthorizationChanges } from "./hooks/Borrower/useLenderAuthorizationChanges"
-// import { useLenderWithdrawalRequests } from "./hooks/Borrower/useLenderWithdrawalRequests"
-// import { useMarketStatusChanges } from "./hooks/Borrower/useMarketStatusChanges"
-// import { useMarketTerminateds } from "./hooks/Borrower/useMarketTerminateds"
-// import { useReserveRatioBipsUpdateds } from "./hooks/Borrower/useReserveRatioBipsUpdateds"
-// import { useWithdrawalBatchCreateds } from "./hooks/Borrower/useWithdrawalBatchCreateds"
-// import { useWithdrawalBatchExpireds } from "./hooks/Borrower/useWithdrawalBatchExpireds"
-// import { useWithdrawalExecutions } from "./hooks/Borrower/useWithdrawalExecutions"
-// import { useAuthorizationChanges } from "./hooks/Lender/useAuthorizationChanges"
-// import { useLenderAPRChanges } from "./hooks/Lender/useLenderAPRChanges"
-// import { useLenderCapacityChanges } from "./hooks/Lender/useLenderCapacityChanges"
-// import { useLenderDepositeds } from "./hooks/Lender/useLenderDepositeds"
-// import { useLenderMarketIds } from "./hooks/Lender/useLenderMarketIds"
-// import { useLenderMarketTerminateds } from "./hooks/Lender/useLenderMarketTerminateds"
-// import { useLenderTokensAvailables } from "./hooks/Lender/useLenderTokensAvailables"
-// import { useLenderWithdrawalResults } from "./hooks/Lender/useLenderWithdrawalResults"
+import { useAPRChanges } from "./hooks/Borrower/useAPRChanges"
+import { useBorrowerMarketIds } from "./hooks/Borrower/useBorrowerMarketIds"
+import { useBorrowerRegistrationChanges } from "./hooks/Borrower/useBorrowerRegistrationChanges"
+import { useBorrows } from "./hooks/Borrower/useBorrows"
+import { useCapacityChanges } from "./hooks/Borrower/useCapacityChanges"
+import { useDebtRepaids } from "./hooks/Borrower/useDebtRepaids"
+import { useDepositeds } from "./hooks/Borrower/useDepositeds"
+import { useLenderAuthorizationChanges } from "./hooks/Borrower/useLenderAuthorizationChanges"
+import { useLenderWithdrawalRequests } from "./hooks/Borrower/useLenderWithdrawalRequests"
+import { useMarketStatusChanges } from "./hooks/Borrower/useMarketStatusChanges"
+import { useMarketTerminateds } from "./hooks/Borrower/useMarketTerminateds"
+import { useReserveRatioBipsUpdateds } from "./hooks/Borrower/useReserveRatioBipsUpdateds"
+import { useWithdrawalBatchCreateds } from "./hooks/Borrower/useWithdrawalBatchCreateds"
+import { useWithdrawalBatchExpireds } from "./hooks/Borrower/useWithdrawalBatchExpireds"
+import { useWithdrawalExecutions } from "./hooks/Borrower/useWithdrawalExecutions"
+import { useAuthorizationChanges } from "./hooks/Lender/useAuthorizationChanges"
+import { useLenderAPRChanges } from "./hooks/Lender/useLenderAPRChanges"
+import { useLenderCapacityChanges } from "./hooks/Lender/useLenderCapacityChanges"
+import { useLenderDepositeds } from "./hooks/Lender/useLenderDepositeds"
+import { useLenderMarketIds } from "./hooks/Lender/useLenderMarketIds"
+import { useLenderMarketTerminateds } from "./hooks/Lender/useLenderMarketTerminateds"
+import { useLenderTokensAvailables } from "./hooks/Lender/useLenderTokensAvailables"
+import { useLenderWithdrawalResults } from "./hooks/Lender/useLenderWithdrawalResults"
 
 const PollingRegistration = () => {
   const { address } = useAccount()
@@ -40,94 +40,96 @@ const PollingRegistration = () => {
   const [lenderMarketIds, setLenderMarketIds] = useState<string[]>([])
   const dispatch = useDispatch()
 
-  // const fetchBorrowerMarketIds = useBorrowerMarketIds(setMarketIds, address)
-  // const fetchLenderMarketIds = useLenderMarketIds(setLenderMarketIds, address)
-  // const fetchBorrowerRegistrationChanges =
-  //   useBorrowerRegistrationChanges(address)
-  // const fetchReserveRatioBipsUpdateds = useReserveRatioBipsUpdateds(
-  //   marketIds,
-  //   address,
-  // )
-  // const fetchLenderAuthorizationChanges = useLenderAuthorizationChanges(
-  //   marketIds,
-  //   address,
-  // )
-  // const fetchBorrows = useBorrows(marketIds, address)
-  // const fetchDebtRepaids = useDebtRepaids(marketIds, address)
-  // const fetchWithdrawalBatchCreateds = useWithdrawalBatchCreateds(
-  //   marketIds,
-  //   address,
-  // )
-  // const fetchWithdrawalBatchExpireds = useWithdrawalBatchExpireds(
-  //   marketIds,
-  //   address,
-  // )
-  // const fetchWithdrawalExecutions = useWithdrawalExecutions(marketIds, address)
+  const fetchBorrowerMarketIds = useBorrowerMarketIds(setMarketIds, address)
+  const fetchLenderMarketIds = useLenderMarketIds(setLenderMarketIds, address)
+  const fetchBorrowerRegistrationChanges =
+    useBorrowerRegistrationChanges(address)
+  const fetchReserveRatioBipsUpdateds = useReserveRatioBipsUpdateds(
+    marketIds,
+    address,
+  )
+  const fetchLenderAuthorizationChanges = useLenderAuthorizationChanges(
+    marketIds,
+    address,
+  )
+  const fetchBorrows = useBorrows(marketIds, address)
+  const fetchDebtRepaids = useDebtRepaids(marketIds, address)
+  const fetchWithdrawalBatchCreateds = useWithdrawalBatchCreateds(
+    marketIds,
+    address,
+  )
+  const fetchWithdrawalBatchExpireds = useWithdrawalBatchExpireds(
+    marketIds,
+    address,
+  )
+  const fetchWithdrawalExecutions = useWithdrawalExecutions(marketIds, address)
 
-  // const fetchAPRChanges = useAPRChanges(address)
-  // // "0x0b776552c1aef1dc33005dd25acda22493b6615d"
-  // const fetchCapacityChanges = useCapacityChanges(address)
-  // const fetchDepositeds = useDepositeds(address)
-  // const fetchLenderWithdrawalRequests = useLenderWithdrawalRequests(address)
-  // const fetchMarketStatusChanges = useMarketStatusChanges(address)
-  // const fetchMarketTerminateds = useMarketTerminateds(address)
+  const fetchAPRChanges = useAPRChanges(address)
+  const fetchCapacityChanges = useCapacityChanges(address)
+  const fetchDepositeds = useDepositeds(address)
+  const fetchLenderWithdrawalRequests = useLenderWithdrawalRequests(address)
+  const fetchMarketStatusChanges = useMarketStatusChanges(address)
+  const fetchMarketTerminateds = useMarketTerminateds(address)
 
-  // const fetchLenderAPRChanges = useLenderAPRChanges(address)
-  // const fetchLenderCapacityChanges = useLenderCapacityChanges(address)
-  // const fetchLenderDepositeds = useLenderDepositeds(address)
-  // const fetchAuthorizationChanges = useAuthorizationChanges(
-  //   lenderMarketIds,
-  //   address,
-  // )
-  // const fetchLenderMarketTerminateds = useLenderMarketTerminateds(
-  //   lenderMarketIds,
-  //   address,
-  // )
-  // const fetchLenderTokensAvailables = useLenderTokensAvailables(address)
-  // const fetchLenderWithdrawalResults = useLenderWithdrawalResults(
-  //   lenderMarketIds,
-  //   address,
-  // )
+  const fetchLenderAPRChanges = useLenderAPRChanges(address)
+  const fetchLenderCapacityChanges = useLenderCapacityChanges(address)
+  const fetchLenderDepositeds = useLenderDepositeds(address)
+  const fetchAuthorizationChanges = useAuthorizationChanges(
+    lenderMarketIds,
+    address,
+  )
+  const fetchLenderMarketTerminateds = useLenderMarketTerminateds(
+    lenderMarketIds,
+    address,
+  )
+  const fetchLenderTokensAvailables = useLenderTokensAvailables(address)
+  const fetchLenderWithdrawalResults = useLenderWithdrawalResults(
+    lenderMarketIds,
+    address,
+  )
 
-  // const fetch = () => {
-  //   fetchBorrowerMarketIds()
-  //   fetchBorrowerRegistrationChanges()
-  //   fetchReserveRatioBipsUpdateds()
-  //   fetchLenderAuthorizationChanges()
-  //   fetchBorrows()
-  //   fetchDebtRepaids()
-  //   fetchWithdrawalBatchCreateds()
-  //   fetchWithdrawalBatchExpireds()
-  //   fetchWithdrawalExecutions()
-  //   fetchAPRChanges()
-  //   fetchCapacityChanges()
-  //   fetchDepositeds()
-  //   fetchLenderWithdrawalRequests()
-  //   fetchMarketStatusChanges()
-  //   fetchMarketTerminateds()
+  const fetch = useCallback(() => {
+    // Borrower data fetchers
+    fetchBorrowerMarketIds()
+    fetchBorrowerRegistrationChanges()
+    fetchReserveRatioBipsUpdateds()
+    fetchLenderAuthorizationChanges()
+    fetchBorrows()
+    fetchDebtRepaids()
+    fetchWithdrawalBatchCreateds()
+    fetchWithdrawalBatchExpireds()
+    fetchWithdrawalExecutions()
+    fetchAPRChanges()
+    fetchCapacityChanges()
+    fetchDepositeds()
+    fetchLenderWithdrawalRequests()
+    fetchMarketStatusChanges()
+    fetchMarketTerminateds()
 
-  //   fetchLenderMarketIds()
-  //   fetchLenderAPRChanges()
-  //   fetchLenderCapacityChanges()
-  //   fetchLenderDepositeds()
-  //   fetchAuthorizationChanges()
-  //   fetchLenderMarketTerminateds()
-  //   fetchLenderTokensAvailables()
-  //   fetchLenderWithdrawalResults()
-  // }
+    // Lender data fetchers
+    fetchLenderMarketIds()
+    fetchLenderAPRChanges()
+    fetchLenderCapacityChanges()
+    fetchLenderDepositeds()
+    fetchAuthorizationChanges()
+    fetchLenderMarketTerminateds()
+    fetchLenderTokensAvailables()
+    fetchLenderWithdrawalResults()
+  }, [address, marketIds.length, lenderMarketIds.length])
 
-  // usePolling({
-  //   callback: fetch,
-  //   interval: POLLING_INTERVAL,
-  // })
+  usePolling({
+    callback: fetch,
+    interval: POLLING_INTERVAL,
+  })
 
-  // useEffect(() => {
-  //   dispatch(clear())
-  //   SubgraphClient.cache.reset()
-  //   if (address) {
-  //     fetch()
-  //   }
-  // }, [address])
+  useEffect(() => {
+    dispatch(clear())
+    SubgraphClient.cache.reset()
+
+    if (address) {
+      fetch()
+    }
+  }, [address, dispatch])
 
   return null
 }

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -3,26 +3,65 @@ import { useEffect, useRef } from "react"
 interface UsePollingOptions {
   callback: () => void
   interval: number
+  runImmediately?: boolean 
 }
 
-export const usePolling = ({ callback, interval }: UsePollingOptions) => {
+export const usePolling = ({
+  callback,
+  interval,
+  runImmediately = true,     // to debug add setTimeout here like setTimeout(() => savedCallback.current(), 2000)
+}: UsePollingOptions) => {
   const savedCallback = useRef<() => void>()
+  // store interval ref
+  const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
     savedCallback.current = callback
   }, [callback])
 
+  
   useEffect(() => {
-    if (!interval || interval <= 0) return
+    const timestamp = new Date().toISOString()
+    console.log(`[${timestamp}] [usePolling] Effect running`, { interval, runImmediately })
 
-    setInterval(() => {
+    // clear existing interval before creating new one
+    if (intervalRef.current) {
+      console.log(`[${timestamp}] [usePolling] Clearing existing interval`)
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+
+    // validate interval is positive
+    if (!interval || interval <= 0) {
+      console.log(`[${timestamp}] [usePolling] Invalid interval`)
+      return undefined
+    }
+
+    if (runImmediately && savedCallback.current) {
+      console.log(`[${timestamp}] [usePolling] Running immediately`)
+      savedCallback.current()
+    }
+
+    // set the polling interval
+    console.log(`[${timestamp}] [usePolling] Setting up interval`)
+    intervalRef.current = setInterval(() => {
+      const tickTimestamp = new Date().toISOString()
+      console.log(`[${tickTimestamp}] [usePolling] Interval tick`)
       if (savedCallback.current) {
         savedCallback.current()
       }
     }, interval)
 
-    if (savedCallback.current) {
-      savedCallback.current()
+    // cleanup function to clear interval when effect reruns or unmounts
+    return () => {
+      const cleanupTimestamp = new Date().toISOString()
+      console.log(`[${cleanupTimestamp}] [usePolling] Cleanup running`)
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
     }
-  }, [interval])
+  }, [interval, runImmediately])
+
+  return null
 }


### PR DESCRIPTION
### Setup :
- spent (too long) setting up local env and getting comfy navigating the repo 
- removed the commented-out polling registooor and got some initial traces:

> ![image](https://github.com/user-attachments/assets/49bf073c-9afb-43e6-9f48-baafdc6677dc)

### Initial investigation
I did some skimming with console logs and found a few interesting areas. Ended up investigating most of them.

- [ ]  `/subgraph.ts` had `nextFetchPolicy: "network-only"` - could be cache related
- [ ] ` state.sort((a, b) => b.blockTimestamp - a.blockTimestamp)`  maybe necessary but this puppy O(n log n) on every notification i think?
- [ ] `getMarketEvents`s downstream is incredibly greedy.
- [x] `PollingRegistration` component used a plain fetch - rerendering or duplication issues potentially
- [x] `usePolling` hook - bug where dangling intervals created

## Scope

Two areas i chose to tackle / focussed mostly on were the usePolling hook and the PollingRegistration component.

### usePolling


Each render creates a new interval without clearing the existing one. this created a dangling interval on each remount that multiplied the number of calls:
<img width="824" alt="image" src="https://github.com/user-attachments/assets/a90bc6f4-a3fc-412e-a2ce-d201d97b8b73" />


rough plan:
- store / track the interval with a reference, fixing the dangling reference
- Implement cleanup function
- add console logging with timestamps to debug lifecycle (remove if ever merge)


#### testing / validated by:
- verified no duplicate intervals when component rerenders
- got *some* confirmation on remounting issues - needing a better method for component lifecycle observability.
<img width="742" alt="image" src="https://github.com/user-attachments/assets/be3f897e-7175-4096-844f-9d01c8d35596" />



#### result:
Intervals now properly cleaned up preventing accumulation of multiple running timers

### PollingRegistration

#### Rough plan:
- wrap fetchs in useCallback 

this definitely needed further testing but it seemed to resolve my 429's
![image](https://github.com/user-attachments/assets/f92487d7-2b8a-4c13-9977-56e366289772)


## Handoff 👀
The areas i wanted to explore but didnt have time or would've needed to ask questions include:

#### `nextFetchPolicy: "network-only"`
Would have liked to spend time looking into the `fetchPolicy` and `nextFetchPolicy` in further detail (subgraph.tsx but also where the fetchPolicy's are defined). 
- What is the intended caching policy here? noting that `fetchPolicy` is used every time the component mounts while `nextFetchPolicy` is used for every query execution after the component mounts.
- Is it mission critical to always go over network? what data (static or other) can be cached 


#### `getMarketsData` downstream
This next part is a bit schizo but - i also tried to integrate the wildcat sdk locally to make changes there but timed out hard. My thoughts are that `getMarketEvents` query surface is either wrong or confusing. My understanding is that the wildcat sdk fetches all event types over the graphql api, then filters them to return only the requested ones? so It appears to fetch all event types in every request - the `kind` filtering only happens after the data is returned.

Thats a rushed attempt at looking for a problem where there may not be one as i wasnt satisfied with that i got done above




*note*: would be interested to know what it looks like running this on your end without all the 500's i was getting from a half-baked setup. 



