### PR TITLE
[#617] Sufficient Reserves timer broke [FIXING]

### DIFF
--- a/src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/index.tsx
+++ b/src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/index.tsx
@@ -1,6 +1,4 @@
 import { Box, Typography } from "@mui/material"
-import { TokenAmount } from "@wildcatfi/wildcat-sdk"
-import { BigNumber } from "ethers"
 import humanizeDuration from "humanize-duration"
 import { useTranslation } from "react-i18next"
 
@@ -9,6 +7,7 @@ import { BarItem } from "@/components/BarChart/BarItem"
 import { MarketBarChartItem } from "@/components/BarChart/BarItem/interface"
 import { LegendItem } from "@/components/BarChart/LegendItem"
 import { COLORS } from "@/theme/colors"
+import { computeSecondsBefore } from "@/utils/computeSecondsBefore"
 import { formatTokenWithCommas } from "@/utils/formatters"
 
 import { CollateralObligationsData } from "./CollateralObligations/CollateralObligationsData"
@@ -56,67 +55,9 @@ export const MarketStatusChart = ({ market }: MarketStatusChartProps) => {
     return "default"
   }
 
-  const SECONDS_IN_365_DAYS = 31_536_000
-  const BIP_RAY_RATIO = BigNumber.from(10).pow(23)
-
-  const bipToRay = (bip: number) => BIP_RAY_RATIO.mul(bip)
-
-  // fallback to compute seconds before delinquency in the case
-  // of zero-reserve-ration where sdk returns 0 seconds
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const computeSecondsBefore = (borrowAmountToken?: TokenAmount): number => {
-    // Use SDK-provided value if non-zero (covers usual reserve-driven case)
-    const sdkSeconds = borrowAmountToken
-      ? market.getSecondsBeforeDelinquencyForBorrowedAmount(borrowAmountToken)
-      : market.secondsBeforeDelinquency
-
-    if (sdkSeconds > 0) return sdkSeconds
-
-    // if sdk says 0 seconds then check if protocol fees are still play-on
-    if (market.totalDebts.gt(0) && !market.isClosed) {
-      // numerator = liquidReserves - minimumReserves (and subtract borrow amount if simulating a tx)
-      // we use this as the buffer that protocol fees can erode over time
-      // start with the base buffer: liquidReserves minus the policy minimum reserves
-      let reserveBuffer = market.liquidReserves.sub(market.minimumReserves)
-      // if we're simulating after a borrow, also subtract the borrow amount from the buffer
-      if (borrowAmountToken) {
-        reserveBuffer = reserveBuffer.sub(borrowAmountToken)
-      }
-
-      // means liquid reserves are at or below minimum after
-      // accounting for the borrow there is no runway for protocol fees
-      if (reserveBuffer.raw.lte(0)) return 0
-
-      try {
-        // calc erosion of reserves per second due to protocol fees
-        // 1) take totalSupply, scale by annual APR (converted to ray)
-        // 2) divide by seconds per year to get per-second interest on supply
-        // 3) take the protocol's share of that interest (protocolFeeBips)
-        const protocolInterestPerSecond = market.totalSupply
-          .rayMul(bipToRay(market.annualInterestBips))
-          .div(SECONDS_IN_365_DAYS)
-          .bipMul(market.protocolFeeBips)
-
-        // if that protocol-driven depletion is non-zero, compute seconds = numerator / rate
-        if (!protocolInterestPerSecond.raw.eq(0)) {
-          // divide the available buffer by the per-second drain to get seconds remaining
-          const seconds = reserveBuffer
-            .div(protocolInterestPerSecond, true)
-            .raw.toNumber()
-          if (seconds > 0) return seconds
-        }
-      } catch (e) {
-        // if anything goes wrong with the math, ignore me and fall back to sdk value (preserve behaviour)
-      }
-    }
-
-    return sdkSeconds
-  }
-
   const remainingInterest =
     market.totalDebts.gt(0) && !market.isClosed
-      ? humanizeDuration(computeSecondsBefore() * 1000, {
+      ? humanizeDuration(computeSecondsBefore(market) * 1000, {
           round: true,
           largest: 1,
         })

--- a/src/app/[locale]/borrower/market/[address]/components/Modals/BorrowModal/index.tsx
+++ b/src/app/[locale]/borrower/market/[address]/components/Modals/BorrowModal/index.tsx
@@ -2,8 +2,6 @@ import { ChangeEvent, useEffect, useState } from "react"
 import * as React from "react"
 
 import { Box, Button, Dialog, Typography } from "@mui/material"
-import { TokenAmount } from "@wildcatfi/wildcat-sdk"
-import { BigNumber } from "ethers"
 import humanizeDuration from "humanize-duration"
 import { useTranslation } from "react-i18next"
 
@@ -24,6 +22,7 @@ import { NumberTextField } from "@/components/NumberTextfield"
 import { TextfieldChip } from "@/components/TextfieldAdornments/TextfieldChip"
 import { TxModalFooter } from "@/components/TxModalComponents/TxModalFooter"
 import { TxModalHeader } from "@/components/TxModalComponents/TxModalHeader"
+import { computeSecondsBefore } from "@/utils/computeSecondsBefore"
 import { formatTokenWithCommas } from "@/utils/formatters"
 
 import { BorrowModalProps } from "./interface"
@@ -75,73 +74,15 @@ export const BorrowModal = ({
 
   const leftBorrowAmount = market.borrowableAssets.sub(underlyingBorrowAmount)
 
-  // Constants used for fallback computation (match SDK values)
-  const SECONDS_IN_365_DAYS = 31_536_000
-  const BIP_RAY_RATIO = BigNumber.from(10).pow(23)
-
-  const bipToRay = (bip: number) => BIP_RAY_RATIO.mul(bip)
-
-  // fallback to compute seconds before delinquency in the case
-  // of zero-reserve-ration where sdk returns 0 seconds
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const computeSecondsBefore = (borrowAmountToken?: TokenAmount): number => {
-    // Use SDK-provided value if non-zero (covers usual reserve-driven case)
-    const sdkSeconds = borrowAmountToken
-      ? market.getSecondsBeforeDelinquencyForBorrowedAmount(borrowAmountToken)
-      : market.secondsBeforeDelinquency
-
-    if (sdkSeconds > 0) return sdkSeconds
-
-    // if sdk says 0 seconds then check if protocol fees are still play-on
-    if (market.totalDebts.gt(0) && !market.isClosed) {
-      // numerator = liquidReserves - minimumReserves (and subtract borrow amount if simulating a tx)
-      // we use this as the buffer that protocol fees can erode over time
-      // start with the base buffer: liquidReserves minus the policy minimum reserves
-      let reserveBuffer = market.liquidReserves.sub(market.minimumReserves)
-      // if we're simulating after a borrow, also subtract the borrow amount from the buffer
-      if (borrowAmountToken) {
-        reserveBuffer = reserveBuffer.sub(borrowAmountToken)
-      }
-
-      // means liquid reserves are at or below minimum after
-      // accounting for the borrow there is no runway for protocol fees
-      if (reserveBuffer.raw.lte(0)) return 0
-
-      try {
-        // calc erosion of reserves per second due to protocol fees
-        // 1) take totalSupply, scale by annual APR (converted to ray)
-        // 2) divide by seconds per year to get per-second interest on supply
-        // 3) take the protocol's share of that interest (protocolFeeBips)
-        const protocolInterestPerSecond = market.totalSupply
-          .rayMul(bipToRay(market.annualInterestBips))
-          .div(SECONDS_IN_365_DAYS)
-          .bipMul(market.protocolFeeBips)
-
-        // if that protocol-driven depletion is non-zero, compute seconds = numerator / rate
-        if (!protocolInterestPerSecond.raw.eq(0)) {
-          // divide the available buffer by the per-second drain to get seconds remaining
-          const seconds = reserveBuffer
-            .div(protocolInterestPerSecond, true)
-            .raw.toNumber()
-          if (seconds > 0) return seconds
-        }
-      } catch (e) {
-        // if anything goes wrong with the math, ignore me and fall back to sdk value (preserve behaviour)
-      }
-    }
-
-    return sdkSeconds
-  }
-
-  const remainingSeconds = computeSecondsBefore()
+  // using shared util computeSecondsBefore(market, borrowAmount?)
+  const remainingSeconds = computeSecondsBefore(market, undefined)
   const remainingInterest =
     market.totalDebts.gt(0) && !market.isClosed
       ? humanizeDuration(remainingSeconds * 1_000, { largest: 1 })
       : ""
 
   const millisecondsBeforeDelinquency =
-    computeSecondsBefore(underlyingBorrowAmount) * 1_000
+    computeSecondsBefore(market, underlyingBorrowAmount) * 1_000
 
   const remainingInterestAfterTx =
     market.totalDebts.gt(0) &&

--- a/src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/index.tsx
+++ b/src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/index.tsx
@@ -37,6 +37,7 @@ import { TxModalFooter } from "@/components/TxModalComponents/TxModalFooter"
 import { TxModalHeader } from "@/components/TxModalComponents/TxModalHeader"
 import { EtherscanBaseUrl } from "@/config/network"
 import { COLORS } from "@/theme/colors"
+import { computeSecondsBefore } from "@/utils/computeSecondsBefore"
 import { isUSDTLikeToken } from "@/utils/constants"
 import { SDK_ERRORS_MAPPING } from "@/utils/errors"
 import { formatTokenWithCommas } from "@/utils/formatters"
@@ -248,67 +249,9 @@ export const RepayModal = ({
 
   const showForm = !(isRepaying || showSuccessPopup || showErrorPopup)
 
-  const SECONDS_IN_365_DAYS = 31_536_000
-  const BIP_RAY_RATIO = BigNumber.from(10).pow(23)
-
-  const bipToRay = (bip: number) => BIP_RAY_RATIO.mul(bip)
-
-  // fallback to compute seconds before delinquency in the case
-  // of zero-reserve-ration where sdk returns 0 seconds
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const computeSecondsBefore = (borrowAmountToken?: TokenAmount): number => {
-    // Use SDK-provided value if non-zero (covers usual reserve-driven case)
-    const sdkSeconds = borrowAmountToken
-      ? market.getSecondsBeforeDelinquencyForBorrowedAmount(borrowAmountToken)
-      : market.secondsBeforeDelinquency
-
-    if (sdkSeconds > 0) return sdkSeconds
-
-    // if sdk says 0 seconds then check if protocol fees are still play-on
-    if (market.totalDebts.gt(0) && !market.isClosed) {
-      // numerator = liquidReserves - minimumReserves (and subtract borrow amount if simulating a tx)
-      // we use this as the buffer that protocol fees can erode over time
-      // start with the base buffer: liquidReserves minus the policy minimum reserves
-      let reserveBuffer = market.liquidReserves.sub(market.minimumReserves)
-      // if we're simulating after a borrow, also subtract the borrow amount from the buffer
-      if (borrowAmountToken) {
-        reserveBuffer = reserveBuffer.sub(borrowAmountToken)
-      }
-
-      // means liquid reserves are at or below minimum after
-      // accounting for the borrow there is no runway for protocol fees
-      if (reserveBuffer.raw.lte(0)) return 0
-
-      try {
-        // calc erosion of reserves per second due to protocol fees
-        // 1) take totalSupply, scale by annual APR (converted to ray)
-        // 2) divide by seconds per year to get per-second interest on supply
-        // 3) take the protocol's share of that interest (protocolFeeBips)
-        const protocolInterestPerSecond = market.totalSupply
-          .rayMul(bipToRay(market.annualInterestBips))
-          .div(SECONDS_IN_365_DAYS)
-          .bipMul(market.protocolFeeBips)
-
-        // if that protocol-driven depletion is non-zero, compute seconds = numerator / rate
-        if (!protocolInterestPerSecond.raw.eq(0)) {
-          // divide the available buffer by the per-second drain to get seconds remaining
-          const seconds = reserveBuffer
-            .div(protocolInterestPerSecond, true)
-            .raw.toNumber()
-          if (seconds > 0) return seconds
-        }
-      } catch (e) {
-        // if anything goes wrong with the math, ignore me and fall back to sdk value (preserve behaviour)
-      }
-    }
-
-    return sdkSeconds
-  }
-
   const remainingInterest =
     market.totalDebts.gt(0) && !market.isClosed
-      ? humanizeDuration(computeSecondsBefore() * 1000, {
+      ? humanizeDuration(computeSecondsBefore(market) * 1000, {
           round: true,
           largest: 1,
         })

--- a/src/utils/computeSecondsBefore.ts
+++ b/src/utils/computeSecondsBefore.ts
@@ -1,0 +1,62 @@
+import {
+  Market,
+  TokenAmount,
+  bipToRay,
+  SECONDS_IN_365_DAYS,
+} from "@wildcatfi/wildcat-sdk"
+
+// fallback to compute seconds before delinquency in the case
+// of zero-reserve-ration where sdk returns 0 seconds
+// TODO: consult with the blade (Dillon) on whether this should be moved to sdk
+
+export function computeSecondsBefore(
+  market: Market,
+  borrowAmountToken?: TokenAmount,
+): number {
+  // use SDK-provided value if non-zero (covers usual reserve-driven case)
+  const sdkSeconds = borrowAmountToken
+    ? market.getSecondsBeforeDelinquencyForBorrowedAmount(borrowAmountToken)
+    : market.secondsBeforeDelinquency
+
+  if (sdkSeconds > 0) return sdkSeconds
+
+  // if sdk says 0 seconds then check if protocol fees are still play-on
+  if (market.totalDebts.gt(0) && !market.isClosed) {
+    // numerator = liquidReserves - minimumReserves (and subtract borrow amount if simulating a tx)
+    // we use this as the buffer that protocol fees can erode over time
+    // start with the base buffer: liquidReserves minus the policy minimum reserves
+    let reserveBuffer = market.liquidReserves.sub(market.minimumReserves)
+    // if we're simulating after a borrow, also subtract the borrow amount from the buffer
+    if (borrowAmountToken) {
+      reserveBuffer = reserveBuffer.sub(borrowAmountToken)
+    }
+
+    // means liquid reserves are at or below minimum after
+    // accounting for the borrow there is no runway for protocol fees
+    if (reserveBuffer.raw.lte(0)) return 0
+
+    try {
+      // calc erosion of reserves per second due to protocol fees
+      // 1) take totalSupply, scale by annual APR (converted to ray)
+      // 2) divide by seconds per year to get per-second interest on supply
+      // 3) take the protocol's share of that interest (protocolFeeBips)
+      const protocolInterestPerSecond = market.totalSupply
+        .rayMul(bipToRay(market.annualInterestBips))
+        .div(SECONDS_IN_365_DAYS)
+        .bipMul(market.protocolFeeBips)
+
+      // if that protocol-driven depletion is non-zero, compute seconds = numerator / rate
+      if (!protocolInterestPerSecond.raw.eq(0)) {
+        // divide the available buffer by the per-second drain to get seconds remaining
+        const seconds = reserveBuffer
+          .div(protocolInterestPerSecond, true)
+          .raw.toNumber()
+        if (seconds > 0) return seconds
+      }
+    } catch (e) {
+      // if anything goes wrong with the math, ignore me and fall back to sdk value (preserve behaviour)
+    }
+  }
+
+  return sdkSeconds
+}


### PR DESCRIPTION
[Sufficient reserve timer not working](https://github.com/wildcat-finance/product/issues/617#issuecomment-3199991197)

TLDR: sdk returns 0 for `secondsBeforeDelinquency` when `reserveRatioBips` is set to zero.

this causes the frontend to display `0 seconds remaining` , which is misleading because markets can still accrue protocol fees that will drain reserves and eventually push the market toward delinquency 

the SDK uses the `reserveRatioBips` to calculate the per-second values, and when that multiplier is zero we always get `0 seconds`.  protocol fees can still drive depletion, and i think it just isn’t considered in that SDK getter

imo there are two possible approaches:

- update / add to SDK to incorporate protocol-fee-driven runway into `secondsBeforeDelinquency`. This would be ideal and means we dont have to maintain the code in multiple places but i would need thoughts/review from @d1ll0n that im not wrong on the calcs or missing stuff.

- fix frontend by adding a util to calculate the seconds remaining based on protocol fee if otherwise sdk returning 0

added a shared util `computeSecondsBefore` and ref that  in `BorrowModal`, `RepayModal`, and the `MarketStatusChart` whenever calculating `interestRemaining` or `interest remaining after tx` so the frontend shows a duration even when the sdk returns 0

