### PR TITLE
feat(auth): JWT Refresh & Expiry

### DIFF
--- a/.github/workflows/vercel-purge.yml
+++ b/.github/workflows/vercel-purge.yml
@@ -1,0 +1,44 @@
+name: Purge Vercel caches (CDN + Data)
+
+on:
+  schedule:
+    - cron: "30 3 */3 * *"
+  workflow_dispatch: {}
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN:      ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID:     ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm i -g vercel@latest
+
+      - name: Sanity check env
+        run: |
+          [ -n "$VERCEL_TOKEN" ]      || { echo "VERCEL_TOKEN is empty"; exit 1; }
+          [ -n "$VERCEL_ORG_ID" ]     || { echo "VERCEL_ORG_ID is empty"; exit 1; }
+          [ -n "$VERCEL_PROJECT_ID" ] || { echo "VERCEL_PROJECT_ID is empty"; exit 1; }
+          echo "Env OK"
+
+      - name: Who am I
+        run: vercel whoami --token "$VERCEL_TOKEN"
+
+      - name: Write .vercel/project.json
+        run: |
+          mkdir -p .vercel
+          cat > .vercel/project.json <<EOF
+          { "orgId": "$VERCEL_ORG_ID", "projectId": "$VERCEL_PROJECT_ID" }
+          EOF
+
+      - name: Pull project settings (prod)
+        run: vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
+
+      - name: Purge CDN cache
+        run: vercel cache purge --type=cdn --yes --token "$VERCEL_TOKEN"
+
+      - name: Purge Data cache
+        run: vercel cache purge --type=data --yes --token "$VERCEL_TOKEN"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.3.4",
+        "@hotjar/browser": "^1.0.9",
         "@mui/material": "^5.15.1",
         "@mui/material-nextjs": "^5.15.0",
         "@mui/system": "^5.15.1",
@@ -3998,6 +3999,11 @@
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
       }
+    },
+    "node_modules/@hotjar/browser": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@hotjar/browser/-/browser-1.0.9.tgz",
+      "integrity": "sha512-n9akDMod8BLGpYEQCrHwlYWWd63c1HlhUSXNIDfClZtKYXbUjIUOFlNZNNcUxgHTCsi4l2i+SWKsGsO0t93S8w=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/src/app/[locale]/admin/hooks/useAllBorrowerInvitations.ts
+++ b/src/app/[locale]/admin/hooks/useAllBorrowerInvitations.ts
@@ -3,12 +3,13 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { BorrowerInvitationForAdminView } from "@/app/api/invite/interface"
-import { useAuthToken } from "@/hooks/useApiAuth"
+import { useAuthToken, useRemoveBadApiToken } from "@/hooks/useApiAuth"
 
 export const GET_ALL_BORROWER_INVITATIONS_KEY = "GET_ALL_BORROWER_INVITATIONS"
 
 export const useAllBorrowerInvitations = () => {
   const token = useAuthToken()
+  const { mutate: removeBadToken } = useRemoveBadApiToken()
   return useQuery({
     queryKey: [
       GET_ALL_BORROWER_INVITATIONS_KEY,
@@ -21,6 +22,10 @@ export const useAllBorrowerInvitations = () => {
           Authorization: `Bearer ${token.token}`,
         },
       })
+      if (response.status === 401) {
+        removeBadToken()
+        throw Error("Failed to fetch borrower invitations")
+      }
       const invitations = (await response.json()).map(
         (x: BorrowerInvitationForAdminView) => ({
           ...x,

--- a/src/app/[locale]/admin/hooks/useAllBorrowerProfiles.ts
+++ b/src/app/[locale]/admin/hooks/useAllBorrowerProfiles.ts
@@ -3,12 +3,13 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { BorrowerProfileForAdminView } from "@/app/api/profiles/interface"
-import { useAuthToken } from "@/hooks/useApiAuth"
+import { useAuthToken, useRemoveBadApiToken } from "@/hooks/useApiAuth"
 
 export const GET_ALL_BORROWER_PROFILES_KEY = "GET_ALL_BORROWER_PROFILES"
 
 export const useAllBorrowerProfiles = () => {
   const token = useAuthToken()
+  const { mutate: removeBadToken } = useRemoveBadApiToken()
   return useQuery({
     queryKey: [GET_ALL_BORROWER_PROFILES_KEY, token?.isAdmin, token?.address],
     queryFn: async () => {
@@ -17,6 +18,10 @@ export const useAllBorrowerProfiles = () => {
           Authorization: `Bearer ${token.token}`,
         },
       })
+      if (response.status === 401) {
+        removeBadToken()
+        throw Error("Failed to fetch borrower profiles")
+      }
       return (await response.json()) as BorrowerProfileForAdminView[]
     },
     enabled: token?.isAdmin,

--- a/src/app/[locale]/borrower/hooks/useBorrowerInvitation.ts
+++ b/src/app/[locale]/borrower/hooks/useBorrowerInvitation.ts
@@ -1,13 +1,14 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { BorrowerInvitation } from "@/app/api/invite/interface"
-import { useAuthToken } from "@/hooks/useApiAuth"
+import { useAuthToken, useRemoveBadApiToken } from "@/hooks/useApiAuth"
 
 export const USE_BORROWER_INVITE_KEY = "use-borrower-invite"
 export const USE_BORROWER_INVITE_EXISTS_KEY = "use-borrower-invite-exists"
 
 export const useGetBorrowerInvitation = (address: string | undefined) => {
   const token = useAuthToken()
+  const { mutate: removeBadToken } = useRemoveBadApiToken()
   const getInvitation = async () => {
     if (!address) return undefined
     const exists = await fetch(`/api/invite/${address.toLowerCase()}`, {
@@ -15,13 +16,16 @@ export const useGetBorrowerInvitation = (address: string | undefined) => {
     }).then((res) => res.status === 200)
     let invitation: BorrowerInvitation | undefined
     if (exists && token) {
-      const result = await fetch(`/api/invite/${address.toLowerCase()}`, {
+      const response = await fetch(`/api/invite/${address.toLowerCase()}`, {
         headers: {
           Authorization: `Bearer ${token.token}`,
         },
       })
-        .then((res) => res.json())
-        .catch(() => undefined)
+      if (response.status === 401) {
+        removeBadToken()
+        throw Error("Failed to get borrower invitation")
+      }
+      const result = await response.json().catch(() => undefined)
       invitation = result?.invitation
     }
     return {
@@ -73,19 +77,23 @@ export const useBorrowerInvitationExists = (address: string | undefined) => {
 
 export const useBorrowerInvitation = (address: string | undefined) => {
   const token = useAuthToken()
+  const { mutate: removeBadToken } = useRemoveBadApiToken()
   const getInvites = async () => {
     if (!address) throw Error(`No address`)
     if (!token) throw Error(`No API token`)
-    const { invitation } = await fetch(`/api/invite/${address.toLowerCase()}`, {
+    const response = await fetch(`/api/invite/${address.toLowerCase()}`, {
       headers: {
         Authorization: `Bearer ${token.token}`,
       },
     })
-      .then((res) => res.json())
-      .catch((err) => {
-        console.log(err)
-        return undefined
-      })
+    if (response.status === 401) {
+      removeBadToken()
+      throw Error("Failed to get borrower invitation")
+    }
+    const { invitation } = await response.json().catch((err) => {
+      console.log(err)
+      return undefined
+    })
     return invitation === undefined ? null : (invitation as BorrowerInvitation)
   }
   const { data, ...result } = useQuery({

--- a/src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/index.tsx
+++ b/src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/index.tsx
@@ -45,6 +45,8 @@ import { RepayModalProps } from "./interface"
 import { DaysSubtitle, PenaltyRepayBtn, PenaltyRepayBtnIcon } from "./style"
 
 const SECONDS_IN_DAY = 24 * 60 * 60
+const EXCEEDS_BALANCE_MESSAGE =
+  "Amount exceeds wallet balance. You can still approve for future use"
 
 export const RepayModal = ({
   buttonType = "marketHeader",
@@ -63,6 +65,7 @@ export const RepayModal = ({
 
   const [showSuccessPopup, setShowSuccessPopup] = useState(false)
   const [showErrorPopup, setShowErrorPopup] = useState(false)
+  const [justApprovedAmount, setJustApprovedAmount] = useState<TokenAmount>()
 
   const [txHash, setTxHash] = useState<string | undefined>("")
 
@@ -115,6 +118,7 @@ export const RepayModal = ({
     setType("sum")
     setDays("")
     setFinalRepayAmount(undefined)
+    setJustApprovedAmount(undefined)
     modal.handleOpenModal()
   }
 
@@ -136,6 +140,10 @@ export const RepayModal = ({
   const repayStep = marketAccount.previewRepay(
     finalRepayAmount || repayAmount,
   ).status
+
+  const isAllowanceSufficient =
+    marketAccount.isApprovedFor(repayAmount) ||
+    (justApprovedAmount && justApprovedAmount.gte(repayAmount))
 
   // const getRepayStep = (inputAmount: TokenAmount) => {
   //   if (market.isClosed) return { status: RepayStatus.MarketClosed }
@@ -160,21 +168,35 @@ export const RepayModal = ({
 
   const handleApprove = () => {
     setTxHash("")
-    if (repayStep === "InsufficientAllowance") {
+    if (!isAllowanceSufficient) {
       if (
         marketAccount.underlyingApproval.gt(0) &&
         isUSDTLikeToken(market.underlyingToken.address)
       ) {
         approve(repayAmount.token.getAmount(0)).then(() => {
           approve(repayAmount).then(() => {
-            setFinalRepayAmount(repayAmount)
-            modal.setFlowStep(ModalSteps.approved)
+            // track that we just approved this amount
+            setJustApprovedAmount(repayAmount)
+            // only clear amount if approving more than balance
+            if (repayAmount.gt(marketAccount.underlyingBalance)) {
+              setAmount("")
+              setDays("")
+              setFinalRepayAmount(undefined)
+            }
+            modal.setFlowStep(ModalSteps.gettingValues)
           })
         })
       } else {
         approve(repayAmount).then(() => {
-          setFinalRepayAmount(repayAmount)
-          modal.setFlowStep(ModalSteps.approved)
+          // track that we just approved this amount
+          setJustApprovedAmount(repayAmount)
+          // only clear amount if approving more than balance
+          if (repayAmount.gt(marketAccount.underlyingBalance)) {
+            setAmount("")
+            setDays("")
+            setFinalRepayAmount(undefined)
+          }
+          modal.setFlowStep(ModalSteps.gettingValues)
         })
       }
     }
@@ -211,7 +233,7 @@ export const RepayModal = ({
     market.isClosed ||
     repayAmount.raw.isZero() ||
     repayStep === "Ready" ||
-    repayStep === "InsufficientBalance" ||
+    isAllowanceSufficient ||
     isApproving
 
   const disableRepay =
@@ -222,7 +244,7 @@ export const RepayModal = ({
     isApproving
 
   const isApprovedButton =
-    repayStep === "Ready" && !repayAmount.raw.isZero() && !isApproving
+    isAllowanceSufficient && !repayAmount.raw.isZero() && !isApproving
 
   const showForm = !(isRepaying || showSuccessPopup || showErrorPopup)
 
@@ -269,6 +291,7 @@ export const RepayModal = ({
     }
     if (isRepaid) {
       setShowSuccessPopup(true)
+      setShowErrorPopup(false)
     }
   }, [isRepayError, isRepaid])
 
@@ -291,16 +314,58 @@ export const RepayModal = ({
       return
     }
 
+    if (repayStep === "InsufficientAllowance") {
+      // warn approval is larger than balance
+      if (repayAmount.gt(marketAccount.underlyingBalance)) {
+        setRepayError(EXCEEDS_BALANCE_MESSAGE)
+      } else {
+        // amount is within balance, just needs approval
+        setRepayError(undefined)
+      }
+      return
+    }
+
+    // when amount > outstanding debt, also check allowance
+    if (repayStep === "InsufficientBalance") {
+      if (!isAllowanceSufficient) {
+        // needs approval - friendly message
+        setRepayError(EXCEEDS_BALANCE_MESSAGE)
+      } else {
+        // has approval but truly insufficient balance
+        setRepayError(SDK_ERRORS_MAPPING.repay[repayStep])
+      }
+      return
+    }
+
+    // can do better later?
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     setRepayError(SDK_ERRORS_MAPPING.repay[repayStep])
-  }, [repayStep, amount])
+  }, [
+    repayStep,
+    amount,
+    days,
+    isRepayByDays,
+    isAllowanceSufficient,
+    repayAmount,
+    marketAccount.underlyingBalance,
+  ])
 
   const { open, closedModalStep } = modal
 
   useEffect(() => {
     setMaxRepayAmount(undefined)
   }, [open, closedModalStep])
+
+  // clear optimistic approval when real approval data catches up
+  useEffect(() => {
+    if (
+      justApprovedAmount &&
+      marketAccount.underlyingApproval.gte(justApprovedAmount.raw)
+    ) {
+      setJustApprovedAmount(undefined)
+    }
+  }, [marketAccount.underlyingApproval, justApprovedAmount])
 
   return (
     <>
@@ -430,6 +495,32 @@ export const RepayModal = ({
 
             {modal.gettingValueStep && (
               <Box>
+                {/* 
+                  // these are helpful for debugging and will show balance / approvals
+                  <Box sx={TxModalInfoItem} padding="0 16px" marginBottom="8px">
+                  <Typography variant="text3" sx={TxModalInfoTitle}>
+                    Current balance
+                  </Typography>
+                  <Typography variant="text3">
+                    {formatTokenWithCommas(marketAccount.underlyingBalance, {
+                      withSymbol: true,
+                    })}
+                  </Typography>
+                </Box>
+                <Box sx={TxModalInfoItem} padding="0 16px" marginBottom="20px">
+                  <Typography variant="text3" sx={TxModalInfoTitle}>
+                    Current allowance
+                  </Typography>
+                  <Typography variant="text3">
+                    {formatTokenWithCommas(
+                      market.underlyingToken.getAmount(
+                        marketAccount.underlyingApproval,
+                      ),
+                      { withSymbol: true },
+                    )}
+                  </Typography>
+                </Box> */}
+
                 <NumberTextField
                   label={amountInputLabel}
                   size="medium"
@@ -445,7 +536,11 @@ export const RepayModal = ({
                   disabled={isApproving}
                   max={type === "days" ? 100000000 : undefined}
                   // decimalScale={2}
-                  error={!!repayError}
+                  error={
+                    !!repayError &&
+                    (repayStep !== "InsufficientBalance" ||
+                      isAllowanceSufficient)
+                  }
                   helperText={repayError}
                 />
 

--- a/src/app/[locale]/borrower/market/[address]/hooks/useGetApproval.ts
+++ b/src/app/[locale]/borrower/market/[address]/hooks/useGetApproval.ts
@@ -1,9 +1,8 @@
-import { Dispatch } from "react"
-
 import { useSafeAppsSDK } from "@safe-global/safe-apps-react-sdk"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Market, Token, TokenAmount } from "@wildcatfi/wildcat-sdk"
 
+import { toastRequest } from "@/components/Toasts"
 import {
   GET_BORROWER_MARKET_ACCOUNT_LEGACY_KEY,
   GET_MARKET_ACCOUNT_KEY,
@@ -12,15 +11,15 @@ import {
 export const useApprove = (
   token: Token,
   market: Market,
-  setTxHash: Dispatch<React.SetStateAction<string | undefined>>,
+  setTxHash?: (hash: string) => void,
 ) => {
   const client = useQueryClient()
   const { connected: safeConnected, sdk } = useSafeAppsSDK()
 
-  return useMutation({
+  const mutation = useMutation({
     mutationFn: async (tokenAmount: TokenAmount) => {
       if (!market) {
-        return
+        throw Error("Market not available")
       }
 
       const approve = async () => {
@@ -29,13 +28,13 @@ export const useApprove = (
           tokenAmount.raw,
         )
 
-        if (!safeConnected) setTxHash(tx.hash)
+        if (!safeConnected && setTxHash) setTxHash(tx.hash)
 
         if (safeConnected) {
           const checkTransaction = async () => {
             const transactionBySafeHash = await sdk.txs.getBySafeTxHash(tx.hash)
             if (transactionBySafeHash?.txHash) {
-              setTxHash(transactionBySafeHash.txHash)
+              if (setTxHash) setTxHash(transactionBySafeHash.txHash)
             } else {
               setTimeout(checkTransaction, 1000)
             }
@@ -56,4 +55,22 @@ export const useApprove = (
       })
     },
   })
+
+  const approveWithToast = async (tokenAmount: TokenAmount) => {
+    await toastRequest(mutation.mutateAsync(tokenAmount), {
+      pending: `Approving ${tokenAmount.format()} ${token.symbol}...`,
+      success: `Successfully approved ${tokenAmount.format()} ${token.symbol}`,
+      error: "Failed to approve",
+    })
+  }
+
+  return {
+    mutateAsync: approveWithToast,
+    mutate: (tokenAmount: TokenAmount) => {
+      approveWithToast(tokenAmount).catch(console.error)
+    },
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+  }
 }

--- a/src/app/[locale]/borrower/profile/edit/hooks/useUpdateBorrowerProfile.ts
+++ b/src/app/[locale]/borrower/profile/edit/hooks/useUpdateBorrowerProfile.ts
@@ -5,7 +5,7 @@ import { GET_ALL_BORROWER_PROFILES_KEY } from "@/app/[locale]/admin/hooks/useAll
 import { BORROWER_PROFILE_KEY } from "@/app/[locale]/borrower/profile/hooks/useGetBorrowerProfile"
 import { BorrowerProfileInput } from "@/app/api/profiles/interface"
 import { toastRequest } from "@/components/Toasts"
-import { useAuthToken } from "@/hooks/useApiAuth"
+import { useAuthToken, useRemoveBadApiToken } from "@/hooks/useApiAuth"
 
 import { USE_REGISTERED_BORROWERS_KEY } from "../../../hooks/useBorrowerNames"
 
@@ -29,6 +29,7 @@ export const useUpdateBorrowerProfile = () => {
   const queryClient = useQueryClient()
   const { address } = useAccount()
   const token = useAuthToken()
+  const { mutate: removeBadToken } = useRemoveBadApiToken()
 
   const updateBorrowerProfile = async (profile: BorrowerProfileInput) => {
     if (!token.token) {
@@ -43,6 +44,9 @@ export const useUpdateBorrowerProfile = () => {
       },
     })
 
+    if (response.status === 401) {
+      removeBadToken()
+    }
     if (!response.ok) {
       throw new Error("Failed to update profile")
     }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -9,6 +9,8 @@ import { LoginInputDTO } from "./dto"
 import { LoginInput } from "./interface"
 import { createApiToken } from "../verify-header"
 
+const MAX_SIGNATURE_AGE = 3_600 // 1 hour
+
 export async function POST(request: NextRequest) {
   let body: LoginInput
   try {
@@ -19,6 +21,11 @@ export async function POST(request: NextRequest) {
   }
   const address = body.address.toLowerCase()
   const { signature, timeSigned } = body
+  // Check if the signature is too old
+  const unixTime = Date.now() / 1000
+  if (timeSigned > unixTime || timeSigned < unixTime - MAX_SIGNATURE_AGE) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 })
+  }
   const LoginMessage = getLoginSignatureMessage(address, timeSigned)
   const provider = getProviderForServer()
   const result = await verifyAndDescribeSignature({

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { createApiToken, verifyApiToken } from "../verify-header"
+
+export async function POST(request: NextRequest) {
+  const token = await verifyApiToken(request)
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  const newToken = await createApiToken(token.address)
+  if (!newToken) {
+    return NextResponse.json({ error: "Server error" }, { status: 500 })
+  }
+  return NextResponse.json(newToken)
+}

--- a/src/app/api/invite/[address]/route.ts
+++ b/src/app/api/invite/[address]/route.ts
@@ -18,8 +18,11 @@ export async function GET(
 ) {
   const address = params.address.toLowerCase()
   const token = await verifyApiToken(request)
-  if (!token?.isAdmin && token?.address.toLowerCase() !== address) {
+  if (!token) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (!token.isAdmin && token.address.toLowerCase() !== address) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
   const invitation = await findBorrowerWithPendingInvitation(address)
   if (invitation) {

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -28,8 +28,11 @@ import { verifyApiToken } from "../auth/verify-header"
 /// Admin-only endpoint.
 export async function GET(request: NextRequest) {
   const token = await verifyApiToken(request)
-  if (!token?.isAdmin) {
+  if (!token) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (!token.isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
   /* const onlyPendingInvitations = request.nextUrl.searchParams.get(
     "onlyPendingInvitations",
@@ -50,7 +53,10 @@ export async function GET(request: NextRequest) {
 /// Admin-only endpoint.
 export async function POST(request: NextRequest) {
   const token = await verifyApiToken(request)
-  if (!token?.isAdmin) {
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (!token.isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
   let body: BorrowerInvitationInput
@@ -219,8 +225,11 @@ export async function POST(request: NextRequest) {
 /// Admin-only endpoint.
 export async function DELETE(request: NextRequest) {
   const token = await verifyApiToken(request)
-  if (!token?.isAdmin) {
+  if (!token) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (!token.isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
   const address = request.nextUrl.searchParams.get("address")
   if (!address) {

--- a/src/app/api/mla/templates/route.ts
+++ b/src/app/api/mla/templates/route.ts
@@ -35,8 +35,11 @@ export async function GET() {
 /// Admin-only endpoint.
 export async function POST(request: NextRequest) {
   const token = await verifyApiToken(request)
-  if (!token?.isAdmin) {
+  if (!token) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (!token.isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
   let body: CreateMlaTemplateInput
   try {

--- a/src/app/api/profiles/[address]/route.ts
+++ b/src/app/api/profiles/[address]/route.ts
@@ -72,8 +72,11 @@ export async function DELETE(
   { params: { address } }: { params: { address: string } },
 ) {
   const token = await verifyApiToken(request)
-  if (!token || !token.isAdmin || TargetChainId !== SupportedChainId.Sepolia) {
+  if (!token) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (!token.isAdmin || TargetChainId !== SupportedChainId.Sepolia) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
   const borrower = address
   if (!borrower) {

--- a/src/components/Toasts/index.tsx
+++ b/src/components/Toasts/index.tsx
@@ -55,12 +55,7 @@ export const toastInfo = (message: string, style: object = {}) =>
   })
 
 export const toastError = (message: string, style: object = {}) =>
-  toast(message, {
-    icon: (
-      <SvgIcon fontSize="small" sx={Icon}>
-        <Check />
-      </SvgIcon>
-    ),
+  toast.error(message, {
     style: {
       ...defaultStyle,
       ...style,

--- a/src/store/slices/apiTokensSlice/apiTokensSlice.ts
+++ b/src/store/slices/apiTokensSlice/apiTokensSlice.ts
@@ -24,5 +24,5 @@ const apiTokensSlice = createSlice({
   },
 })
 
-export const { setApiToken } = apiTokensSlice.actions
+export const { setApiToken, removeApiToken } = apiTokensSlice.actions
 export default persistReducer(persistConfig, apiTokensSlice.reducer)


### PR DESCRIPTION
**API**
- Adds `/api/auth/refresh` route to get a new JWT with an existing unexpired one
- Sets an actual expiration on JWTs (1 week)
- Disallows login with signature timestamp in the future / more than 1 hour in the past
- Modified all privileged routes to only return 401 if the token is actually invalid, and 403 if the token has insufficient access

**Client**
- In `useAuthToken`:
-- Automatically attempts to refresh if it is more than an hour old
-- Automatically removes JWT if refresh fails with 401 or if it is expired
- In all privileged API calls, automatically deletes JWT if server responds with 401