### PR TITLE
chore(ci): fix Release Please config (manifest mode + baseline)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: rp
         with:
-          release-type: node
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          bootstrap-sha: 6cf2f08b20d83fe97eccfbdd7fefd9dad1fe1763

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
**Description**
Switch Release Please to manifest mode so it respects the baseline version and generates tags/CHANGELOG correctly.

**Changes**
- Use config-file + manifest-file in workflow
- Baseline set in .release-please-manifest.json (e.g. 2.0.0)
- Disable component in tag: include-component-in-tag: false