### PR TITLE
fix(delinquency): partially hide delinquency timer on edge cases

### DIFF
--- a/src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/index.tsx
+++ b/src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/index.tsx
@@ -54,8 +54,13 @@ export const MarketStatusChart = ({ market }: MarketStatusChartProps) => {
     return "default"
   }
 
+  // when sdk returns 0 seconds or int.MAX it means there is no countdown to delinquency
+  const displayableSeconds =
+    market.secondsBeforeDelinquency > 0 &&
+    market.secondsBeforeDelinquency < Number.MAX_SAFE_INTEGER
+
   const remainingInterest =
-    market.totalDebts.gt(0) && !market.isClosed
+    market.totalDebts.gt(0) && !market.isClosed && displayableSeconds
       ? humanizeDuration(market.secondsBeforeDelinquency * 1000, {
           round: true,
           largest: 1,
@@ -89,7 +94,8 @@ export const MarketStatusChart = ({ market }: MarketStatusChartProps) => {
       {!isDelinquent &&
         !market.isClosed &&
         !market.isIncurringPenalties &&
-        market.outstandingTotalSupply.gt(0) && (
+        market.outstandingTotalSupply.gt(0) &&
+        remainingInterest && (
           <Box sx={{ display: "flex", columnGap: "3px", marginBottom: "24px" }}>
             <Typography variant="text3" sx={{ color: COLORS.santasGrey }}>
               {t("borrowerMarketDetails.statusChart.sufficientReserves")}

--- a/src/app/[locale]/borrower/market/[address]/components/Modals/BorrowModal/index.tsx
+++ b/src/app/[locale]/borrower/market/[address]/components/Modals/BorrowModal/index.tsx
@@ -73,22 +73,29 @@ export const BorrowModal = ({
 
   const leftBorrowAmount = market.borrowableAssets.sub(underlyingBorrowAmount)
 
+  const displayableSeconds =
+    market.secondsBeforeDelinquency > 0 &&
+    market.secondsBeforeDelinquency < Number.MAX_SAFE_INTEGER
+
   const remainingInterest =
-    market.totalDebts.gt(0) && !market.isClosed
+    market.totalDebts.gt(0) && !market.isClosed && displayableSeconds
       ? humanizeDuration(market.secondsBeforeDelinquency * 1_000, {
           largest: 1,
         })
       : ""
 
-  const millisecondsBeforeDelinquency =
-    market.getSecondsBeforeDelinquencyForBorrowedAmount(
-      underlyingBorrowAmount,
-    ) * 1_000
+  const secondsBeforeDelinquencyAfterTx =
+    market.getSecondsBeforeDelinquencyForBorrowedAmount(underlyingBorrowAmount)
+  const displayableSecondsAfterTx =
+    secondsBeforeDelinquencyAfterTx > 0 &&
+    secondsBeforeDelinquencyAfterTx < Number.MAX_SAFE_INTEGER
+  const millisecondsBeforeDelinquency = secondsBeforeDelinquencyAfterTx * 1_000
 
   const remainingInterestAfterTx =
     market.totalDebts.gt(0) &&
     !market.isClosed &&
-    underlyingBorrowAmount.lt(market.borrowableAssets)
+    underlyingBorrowAmount.lt(market.borrowableAssets) &&
+    displayableSecondsAfterTx
       ? humanizeDuration(millisecondsBeforeDelinquency, {
           largest: 1,
         })
@@ -169,18 +176,22 @@ export const BorrowModal = ({
               </Typography>
             </Box>
 
-            <Box sx={TxModalInfoItem} marginBottom="20px">
-              <Typography variant="text3" sx={TxModalInfoTitle}>
-                {t("borrowerMarketDetails.modals.borrow.interestRemaining")}
-                {modal.approvedStep &&
-                  t("borrowerMarketDetails.modals.borrow.afterTransaction")}
-              </Typography>
-              <Typography variant="text3">
-                {modal.approvedStep
-                  ? remainingInterestAfterTx
-                  : remainingInterest}
-              </Typography>
-            </Box>
+            {(modal.approvedStep
+              ? !!remainingInterestAfterTx
+              : !!remainingInterest) && (
+              <Box sx={TxModalInfoItem} marginBottom="20px">
+                <Typography variant="text3" sx={TxModalInfoTitle}>
+                  {t("borrowerMarketDetails.modals.borrow.interestRemaining")}
+                  {modal.approvedStep &&
+                    t("borrowerMarketDetails.modals.borrow.afterTransaction")}
+                </Typography>
+                <Typography variant="text3">
+                  {modal.approvedStep
+                    ? remainingInterestAfterTx
+                    : remainingInterest}
+                </Typography>
+              </Box>
+            )}
 
             {!modal.approvedStep && (
               <NumberTextField

--- a/src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/index.tsx
+++ b/src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/index.tsx
@@ -248,8 +248,12 @@ export const RepayModal = ({
 
   const showForm = !(isRepaying || showSuccessPopup || showErrorPopup)
 
+  const displayableSeconds =
+    market.secondsBeforeDelinquency > 0 &&
+    market.secondsBeforeDelinquency < Number.MAX_SAFE_INTEGER
+
   const remainingInterest =
-    market.totalDebts.gt(0) && !market.isClosed
+    market.totalDebts.gt(0) && !market.isClosed && displayableSeconds
       ? humanizeDuration(market.secondsBeforeDelinquency * 1000, {
           round: true,
           largest: 1,
@@ -257,9 +261,9 @@ export const RepayModal = ({
       : ""
 
   const amountInputLabel = isRepayByDays
-    ? `${t(
-        "borrowerMarketDetails.modals.repay.interestRemaining",
-      )} ${remainingInterest}`
+    ? `${t("borrowerMarketDetails.modals.repay.interestRemaining")}${
+        remainingInterest ? ` ${remainingInterest}` : ""
+      }`
     : `${t("borrowerMarketDetails.modals.repay.upTo")} ${formatTokenWithCommas(
         market.outstandingDebt,
         {

--- a/src/utils/marketStatus.ts
+++ b/src/utils/marketStatus.ts
@@ -36,7 +36,9 @@ export const getMarketStatusChip = (market: Market) => {
     healthyPeriod:
       market.totalDebts.gt(0) &&
       market.effectiveBorrowerAPR.gt(0) &&
-      market.reserveRatioBips !== 0
+      market.reserveRatioBips !== 0 &&
+      market.secondsBeforeDelinquency > 0 &&
+      market.secondsBeforeDelinquency < Number.MAX_SAFE_INTEGER
         ? market.secondsBeforeDelinquency * 1000
         : null,
     penaltyPeriod: secondsToDays(penaltyPeriod),


### PR DESCRIPTION
This change accompanies the sdk patch that fixes the secondsUntilDelinquency timer.

Overall the correct durations will now display and edge cases handled as follows:

  - If `reserveRatioBips = 0%`: lender portion of requirement growth is zero and only protocol fees progress it.
  - If `reserveRatioBips > 0%` : both lender interest accrual and protocol fee accrual drive delinquency counter

therefore:
- if market reserves are already insufficient the timer no longer shows `0 seconds` and instead shows nothing
-  apr=0 and rr=0 (edge case) then the timer no longer shows `0 seconds` and instead shows nothing

<img width="366" height="104" alt="image" src="https://github.com/user-attachments/assets/7f01f6e7-9f58-430d-90e2-2a9a3433f8ce" />

<img width="348" height="88" alt="image" src="https://github.com/user-attachments/assets/74865f1e-df70-4c4d-a799-6604caaa4457" />
