### PR TITLE
[631]: Withdrawal currencies stuck 

### DIFF
--- a/src/app/[locale]/borrower/market/[address]/hooks/useGetWithdrawals.ts
+++ b/src/app/[locale]/borrower/market/[address]/hooks/useGetWithdrawals.ts
@@ -231,7 +231,7 @@ export function useGetWithdrawals(
     isError: isErrorUpdate,
     failureReason: errorUpdate,
   } = useQuery({
-    queryKey: [GET_WITHDRAWALS_KEY, "update", updateQueryKeys],
+    queryKey: [GET_WITHDRAWALS_KEY, "update", address, updateQueryKeys],
     queryFn: getUpdatedBatches,
     placeholderData: keepPreviousData,
     enabled: !!data,

--- a/src/app/[locale]/lender/market/[address]/hooks/useGetLenderWithdrawals.ts
+++ b/src/app/[locale]/lender/market/[address]/hooks/useGetLenderWithdrawals.ts
@@ -252,7 +252,13 @@ export function useGetLenderWithdrawals(
     isError: isErrorUpdate,
     failureReason: errorUpdate,
   } = useQuery({
-    queryKey: [GET_LENDER_WITHDRAWALS_KEY, "update", updateQueryKeys],
+    queryKey: [
+      GET_LENDER_WITHDRAWALS_KEY,
+      "update",
+      marketAddress,
+      lender,
+      updateQueryKeys,
+    ],
     queryFn: updateWithdrawals,
     placeholderData: keepPreviousData,
     enabled: !!data,


### PR DESCRIPTION
[Link to issue](https://github.com/wildcat-finance/product/issues/631)

TLDR: the hook that fetched the `ongoing WDs` wasnt scoped to a specific address so would occasionally serve a stale result for a previously viewed market

Fix adds address the borrower side hook and also added lender side too since i noticed it there also