### PR TITLE
fix(adoption): borrower 4626 adoption stats wrong

### DIFF
--- a/src/components/MarketParameters/index.tsx
+++ b/src/components/MarketParameters/index.tsx
@@ -11,7 +11,7 @@ import { SeeMoreButton } from "@/components/Mobile/SeeMoreButton"
 import { useBlockExplorer } from "@/hooks/useBlockExplorer"
 import { useEthersProvider } from "@/hooks/useEthersSigner"
 import { useMobileResolution } from "@/hooks/useMobileResolution"
-import { useWrapperBalances } from "@/hooks/wrapper/useWrapperBalances"
+import { useAdoptionData } from "@/hooks/wrapper/useAdoptionData"
 import { formatDate } from "@/lib/mla"
 import { COLORS } from "@/theme/colors"
 import {
@@ -155,30 +155,29 @@ export const MarketParameters = ({
     chainId: market?.chainId,
   })
 
-  const { data: balances } = useWrapperBalances(
+  const { data: adoptionData } = useAdoptionData(
     market?.chainId,
     wrapper,
+    viewerType,
     address,
   )
 
-  const marketValue = balances?.marketBalance
-    ? formatTokenWithCommas(balances?.marketBalance)
+  const marketValue = adoptionData
+    ? formatTokenWithCommas(adoptionData.originalAmount)
     : "0"
-  const shareValue = balances?.shareBalance
-    ? formatTokenWithCommas(balances?.shareBalance)
+  const shareValue = adoptionData
+    ? formatTokenWithCommas(adoptionData.wrappedAmount)
     : "0"
 
-  const marketFloat = balances?.marketBalance
-    ? parseFloat(balances.marketBalance.format(balances.marketBalance.decimals))
+  const adoptionTotal = adoptionData
+    ? adoptionData.originalAssetValue + adoptionData.wrappedAssetValue
     : 0
-  const sharesFloat = balances?.shareBalance
-    ? parseFloat(balances.shareBalance.format(balances.shareBalance.decimals))
-    : 0
-  const adoptionTotal = marketFloat + sharesFloat
-  const marketPct =
-    adoptionTotal > 0 ? ((marketFloat / adoptionTotal) * 100).toFixed(0) : "0"
-  const sharesPct =
-    adoptionTotal > 0 ? ((sharesFloat / adoptionTotal) * 100).toFixed(0) : "0"
+  const marketPctNum =
+    adoptionTotal > 0
+      ? Math.round((adoptionData!.originalAssetValue / adoptionTotal) * 100)
+      : 0
+  const marketPct = String(marketPctNum)
+  const sharesPct = String(adoptionTotal > 0 ? 100 - marketPctNum : 0)
 
   const adoptionStatsTooltip =
     viewerType === "lender"
@@ -384,7 +383,11 @@ export const MarketParameters = ({
                   marketAmount={marketValue}
                   marketAsset={wrapper.marketToken.symbol}
                   sharesAmount={shareValue}
-                  sharesAsset={wrapper.shareToken.symbol}
+                  sharesAsset={
+                    viewerType === "borrower"
+                      ? wrapper.marketToken.symbol
+                      : wrapper.shareToken.symbol
+                  }
                   marketPct={marketPct}
                   sharesPct={sharesPct}
                 />

--- a/src/components/WrapDebtToken/WrapperSection/index.tsx
+++ b/src/components/WrapDebtToken/WrapperSection/index.tsx
@@ -648,6 +648,14 @@ export const WrapperSection = ({
           address,
         ),
       })
+      client.invalidateQueries({
+        queryKey: QueryKeys.Wrapper.GET_ADOPTION(
+          market?.chainId ?? 0,
+          wrapper.address,
+          "lender",
+          address,
+        ),
+      })
       setAmount("")
       setShowSuccess(true)
     },

--- a/src/config/query-keys.ts
+++ b/src/config/query-keys.ts
@@ -301,6 +301,20 @@ const WRAPPER_QUERY_KEYS = {
     k(["wrapper", "GET_ALLOWANCE", chainId, wrapperAddress, account]),
   GET_LIMITS: (chainId: number, wrapperAddress?: string, account?: string) =>
     k(["wrapper", "GET_LIMITS", chainId, wrapperAddress, account]),
+  GET_ADOPTION: (
+    chainId: number,
+    wrapperAddress?: string,
+    viewerType?: string,
+    account?: string,
+  ) =>
+    k([
+      "wrapper",
+      "GET_ADOPTION",
+      chainId,
+      wrapperAddress,
+      viewerType,
+      account,
+    ]),
   PREVIEW: (
     wrapperAddress?: string,
     tab?: string,

--- a/src/hooks/wrapper/useAdoptionData.ts
+++ b/src/hooks/wrapper/useAdoptionData.ts
@@ -1,0 +1,96 @@
+import { useQuery } from "@tanstack/react-query"
+import { TokenAmount, TokenWrapper } from "@wildcatfi/wildcat-sdk"
+
+import { POLLING_INTERVAL } from "@/config/polling"
+import { QueryKeys } from "@/config/query-keys"
+
+export type AdoptionData = {
+  originalAmount: TokenAmount
+  wrappedAmount: TokenAmount
+  originalAssetValue: number
+  wrappedAssetValue: number
+}
+
+/**
+ fetches adoption data for the wrapper
+ *
+ * - lender: personal balances. Shares are converted to their underlying
+ *   asset equivalent so percentages match.
+ *
+ * - borrower: market-wide adoption. shows how much of is split between normal vs wrapped.
+ *   `unwrapped = totalSupply - totalAssets` to avoid double-counting, since
+ *   totalAssets are market tokens held by the wrapper and already included in
+ *   totalSupply.
+ */
+export const useAdoptionData = (
+  chainId: number | undefined,
+  wrapper: TokenWrapper | undefined,
+  viewerType: "lender" | "borrower",
+  account: string | undefined,
+) =>
+  useQuery({
+    queryKey: QueryKeys.Wrapper.GET_ADOPTION(
+      chainId ?? 0,
+      wrapper?.address,
+      viewerType,
+      account,
+    ),
+    enabled: !!chainId && !!wrapper && (viewerType === "borrower" || !!account),
+    refetchInterval: POLLING_INTERVAL,
+    queryFn: async (): Promise<AdoptionData> => {
+      if (!wrapper) throw new Error("Missing wrapper")
+      // borrower
+      if (viewerType === "borrower") {
+        const [totalSupplyRaw, totalAssets] = await Promise.all([
+          wrapper.marketToken.contract.totalSupply(),
+          wrapper.totalAssets(), // returns TokenAmount in market-token terms
+        ])
+        const totalSupply = wrapper.marketToken.getAmount(totalSupplyRaw)
+        const unwrapped = totalSupply.sub(totalAssets)
+        const unwrappedFloat = parseFloat(
+          unwrapped.format(unwrapped.token.decimals),
+        )
+        const wrappedFloat = parseFloat(
+          totalAssets.format(totalAssets.token.decimals),
+        )
+
+        return {
+          originalAmount: unwrapped,
+          wrappedAmount: totalAssets,
+          originalAssetValue: unwrappedFloat,
+          wrappedAssetValue: wrappedFloat,
+        }
+      }
+
+      // lender
+      if (!account) throw new Error("Missing account")
+
+      const [marketBalanceRaw, shareBalanceRaw] = await Promise.all([
+        wrapper.marketToken.contract.balanceOf(account),
+        wrapper.shareToken.contract.balanceOf(account),
+      ])
+
+      const marketBalance = wrapper.marketToken.getAmount(marketBalanceRaw)
+      const shareBalance = wrapper.shareToken.getAmount(shareBalanceRaw)
+
+      const sharesAsAssets = shareBalanceRaw.gt(0)
+        ? await wrapper.convertToAssets(shareBalance)
+        : wrapper.marketToken.getAmount(0)
+
+      const marketFloat = parseFloat(
+        marketBalance.format(marketBalance.token.decimals),
+      )
+      const sharesAsAssetsFloat = parseFloat(
+        sharesAsAssets.format(sharesAsAssets.token.decimals),
+      )
+
+      return {
+        originalAmount: marketBalance,
+        wrappedAmount: shareBalance,
+        originalAssetValue: marketFloat,
+        wrappedAssetValue: sharesAsAssetsFloat,
+      }
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  })


### PR DESCRIPTION
use a proper query and differentiates between borrower and lender paths.

- for lenders: shows *their personal* split of wrapped/unwrapped
- for borrowers: shows the market-wide split of wrapped/unwrapped
