### PR TITLE
fix: fail early on undefined secret in verifyApiToken and remove profile delete route

### DIFF
--- a/src/app/api/auth/verify-header.ts
+++ b/src/app/api/auth/verify-header.ts
@@ -10,13 +10,16 @@ const TOKEN_TTL = 604_800 // 1 week
 export const verifyApiToken = async (
   request: NextRequest,
 ): Promise<DataStoredInToken | undefined> => {
+  const { SECRET_KEY } = process.env
   const authHeader = request.headers.get("authorization")
   if (!authHeader) {
     return undefined
   }
   const token = authHeader.replace("Bearer ", "")
+  const secretKey = SECRET_KEY
+  if (!secretKey) return undefined
   try {
-    const user = verify(token, process.env.SECRET_KEY as string)
+    const user = verify(token, secretKey)
     if (!user) return undefined
     return user as DataStoredInToken
   } catch (err) {

--- a/src/app/api/profiles/profile.test.ts
+++ b/src/app/api/profiles/profile.test.ts
@@ -31,7 +31,6 @@ import {
   GET as getProfileUpdateRequests,
   POST as postProfileUpdateRequest,
   PUT as putProfileUpdateRequest,
-  DELETE as deleteProfileUpdateRequest,
 } from "./updates/route"
 import { LoginInput } from "../auth/login/interface"
 import { POST as postLogin } from "../auth/login/route"

--- a/src/app/api/profiles/updates/route.ts
+++ b/src/app/api/profiles/updates/route.ts
@@ -313,29 +313,4 @@ export async function PUT(request: NextRequest) {
   return NextResponse.json({ success: true })
 }
 
-// DELETE /api/profiles/updates?borrower=<borrower>&chainId=<chainId>
-// Test function only
-export async function DELETE(request: NextRequest) {
-  const chainId = validateChainIdParam(request)
-  if (!chainId) {
-    return NextResponse.json({ error: "Invalid chain ID" }, { status: 400 })
-  }
-  const borrower = request.nextUrl.searchParams.get("borrower")
-  if (!borrower) {
-    return NextResponse.json(
-      { success: false, message: "No Borrower Provided" },
-      { status: 400 },
-    )
-  }
-
-  const result = await prisma.borrowerProfileUpdateRequest.deleteMany({
-    where: {
-      chainId,
-      ...(borrower && { address: borrower }),
-    },
-  })
-
-  return NextResponse.json({ success: true, deleted: result.count })
-}
-
 export const dynamic = "force-dynamic"


### PR DESCRIPTION
## Summary

Two small API changes:

- **`verifyApiToken`**: short-circuit to `undefined` when `SECRET_KEY` is unset, mirroring the existing check in `createApiToken`. Behaviour is effectively the same today — `jsonwebtoken`'s `verify` throws on a missing secret and the `try/catch` swallows it — but this makes the behavior consistent.
- **`DELETE /api/profiles/updates`**: remove the handler