### PR TITLE
fix(borrower-names): expand query key to include chain

### DIFF
--- a/src/app/[locale]/borrower/hooks/useBorrowerNames.ts
+++ b/src/app/[locale]/borrower/hooks/useBorrowerNames.ts
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query"
 
+import { QueryKeys } from "@/config/query-keys"
 import { useSelectedNetwork } from "@/hooks/useSelectedNetwork"
 import { trimAddress } from "@/utils/formatters"
-
-export const USE_REGISTERED_BORROWERS_KEY = "use-borrower-names"
 
 export type BorrowerWithName = {
   address: string
@@ -29,7 +28,7 @@ export const useBorrowerNames = () => {
   }
   const { data, ...result } = useQuery({
     enabled: true,
-    queryKey: [USE_REGISTERED_BORROWERS_KEY],
+    queryKey: QueryKeys.User.GET_BORROWER_NAMES(chainId),
     queryFn: getBorrowers,
     refetchOnMount: false,
     refetchInterval: 10_000,

--- a/src/app/[locale]/borrower/profile/edit/hooks/useUpdateBorrowerProfile.ts
+++ b/src/app/[locale]/borrower/profile/edit/hooks/useUpdateBorrowerProfile.ts
@@ -6,8 +6,6 @@ import { toastRequest } from "@/components/Toasts"
 import { QueryKeys } from "@/config/query-keys"
 import { useAuthToken, useRemoveBadApiToken } from "@/hooks/useApiAuth"
 
-import { USE_REGISTERED_BORROWERS_KEY } from "../../../hooks/useBorrowerNames"
-
 const hashData = async (data: object): Promise<string> => {
   const encoder = new TextEncoder()
   const encodedData = encoder.encode(JSON.stringify(data))
@@ -110,7 +108,7 @@ export const useUpdateBorrowerProfile = () => {
         ),
       })
       queryClient.invalidateQueries({
-        queryKey: [USE_REGISTERED_BORROWERS_KEY],
+        queryKey: QueryKeys.User.GET_BORROWER_NAMES(chainId),
       })
       if (token.isAdmin) {
         queryClient.invalidateQueries({

--- a/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/OtherMarketsTables/index.tsx
+++ b/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/OtherMarketsTables/index.tsx
@@ -13,7 +13,6 @@ import { useTranslation } from "react-i18next"
 
 import { TypeSafeColDef } from "@/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/interface"
 import { LinkCell } from "@/app/[locale]/borrower/components/MarketsTables/style"
-import { useBorrowerNames } from "@/app/[locale]/borrower/hooks/useBorrowerNames"
 import {
   clickableGridSx,
   rowLinkInteractiveSx,
@@ -58,6 +57,7 @@ import {
 
 export const OtherMarketsTables = ({
   marketAccounts,
+  borrowers,
   isLoading,
   filters,
 }: LenderOtherMarketsTableProps) => {
@@ -89,8 +89,6 @@ export const OtherMarketsTables = ({
       }
     }
   }, [dispatch, isMobile, scrollTargetId])
-
-  const { data: borrowers } = useBorrowerNames()
 
   const rows: GridRowsProp<LenderOtherMarketsTableModel> = marketAccounts.map(
     (account) => {

--- a/src/app/api/borrower-names/route.ts
+++ b/src/app/api/borrower-names/route.ts
@@ -22,7 +22,8 @@ export async function GET(request: NextRequest) {
     })
   ).map(({ name, alias, address }) => ({
     address,
-    name: alias || name || undefined,
+    name: name || undefined,
+    alias: alias || undefined,
   }))
   return NextResponse.json(names)
 }


### PR DESCRIPTION
the `borrower-names` query key was static so cross-chain would make it go stale until force refresh after few sec.

the second problem was that the api call collapsed `name` and `alias` into `borrower.alias` which could return undefined and any search by alias would fail silently