### PR TITLE
fix(layout): contain market table scrollbars and width transitions

### DIFF
--- a/src/app/[locale]/borrower/components/MarketsSection/index.tsx
+++ b/src/app/[locale]/borrower/components/MarketsSection/index.tsx
@@ -359,12 +359,17 @@ export const MarketsSection = () => {
     <Box
       sx={{
         width: "100%",
+        flex: "1 1 0",
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
       }}
     >
       <Box
         sx={{
           display: "flex",
           flexDirection: "column",
+          flexShrink: 0,
         }}
       >
         <Box

--- a/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/BorrowerActiveMarketsTables/index.tsx
+++ b/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/BorrowerActiveMarketsTables/index.tsx
@@ -29,7 +29,6 @@ import {
   tokenAmountComparator,
   typeComparator,
 } from "@/utils/comparators"
-import { pageCalcHeights } from "@/utils/constants"
 import {
   buildMarketHref,
   formatBps,
@@ -361,7 +360,8 @@ export const BorrowerActiveMarketsTables = ({
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: `calc(100vh - ${pageCalcHeights.dashboard})`,
+        flex: "1 1 0",
+        minHeight: 0,
         width: "100%",
         overflow: "auto",
         overflowY: "auto",

--- a/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/BorrowerTerminatedMarketsTables/index.tsx
+++ b/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/BorrowerTerminatedMarketsTables/index.tsx
@@ -25,7 +25,6 @@ import { useAppDispatch, useAppSelector } from "@/store/hooks"
 import { setScrollTarget } from "@/store/slices/marketsOverviewSidebarSlice/marketsOverviewSidebarSlice"
 import { COLORS } from "@/theme/colors"
 import { statusComparator, tokenAmountComparator } from "@/utils/comparators"
-import { pageCalcHeights } from "@/utils/constants"
 import {
   buildMarketHref,
   formatBps,
@@ -293,7 +292,8 @@ export const BorrowerTerminatedMarketsTables = ({
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: `calc(100vh - ${pageCalcHeights.dashboard})`,
+        flex: "1 1 0",
+        minHeight: 0,
         width: "100%",
         overflow: "auto",
         overflowY: "auto",

--- a/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/OtherMarketsTables/index.tsx
+++ b/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/OtherMarketsTables/index.tsx
@@ -37,7 +37,6 @@ import {
   tokenAmountComparator,
   typeComparator,
 } from "@/utils/comparators"
-import { pageCalcHeights } from "@/utils/constants"
 import {
   buildMarketHref,
   formatBps,
@@ -460,7 +459,8 @@ export const OtherMarketsTables = ({
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: `calc(100vh - ${pageCalcHeights.dashboard})`,
+        flex: "1 1 0",
+        minHeight: 0,
         width: "100%",
         overflow: "auto",
         overflowY: "auto",

--- a/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/style.ts
+++ b/src/app/[locale]/borrower/components/MarketsSection/сomponents/MarketsTables/style.ts
@@ -3,7 +3,7 @@ import { COLORS } from "@/theme/colors"
 export const DataGridSx = {
   overflow: "visible",
   height: "auto !important",
-  maxWidth: "calc(100vw - 267px)",
+  maxWidth: "100%",
   padding: "0 16px",
   "& .MuiDataGrid-main": {
     overflow: "visible",
@@ -21,6 +21,12 @@ export const DataGridSx = {
   "& .MuiDataGrid-virtualScrollerRenderZone": {
     position: "static !important" as const,
     transform: "none !important",
+  },
+  "& .MuiDataGrid-scrollbar": {
+    display: "none",
+  },
+  "& .MuiDataGrid-scrollbarFiller": {
+    display: "none",
   },
   "& .MuiDataGrid-columnHeaders": {
     position: "sticky",

--- a/src/app/[locale]/borrower/page.tsx
+++ b/src/app/[locale]/borrower/page.tsx
@@ -135,7 +135,11 @@ export default function BorrowerPage() {
     <Box
       sx={{
         padding: "32px 0 0",
-        overflow: "hidden",
+        flex: "1 1 0",
+        minHeight: 0,
+        minWidth: 0,
+        display: "flex",
+        flexDirection: "column",
       }}
     >
       {section === BorrowerDashboardSections.MARKETS && <MarketsSection />}

--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -1,9 +1,4 @@
-html {
-    width: 100vw;
-}
-
 body {
-    height: 100vh;
     margin: 0;
     padding: 0;
 }

--- a/src/app/[locale]/layout-style.ts
+++ b/src/app/[locale]/layout-style.ts
@@ -20,12 +20,22 @@ export const BackgroundContainer = {
   },
 }
 
+export const RootScaffold = {
+  position: "relative",
+  height: "100dvh",
+  display: "flex",
+  flexDirection: "column",
+}
+
 export const PageContainer = {
   borderRadius: "12px 12px 0px 0px",
   backgroundColor: "white",
 
   display: "flex",
   flexDirection: "column",
+
+  flex: "1 1 auto",
+  minHeight: 0,
 
   "@media (max-width: 1000px)": {
     backgroundColor: "transparent",
@@ -34,14 +44,24 @@ export const PageContainer = {
 }
 
 export const ContentContainer = {
-  height: "calc(100vh - 82px)",
   width: "100%",
   display: "flex",
   flexDirection: "row",
 
+  flex: "1 1 auto",
+  minHeight: 0,
+  minWidth: 0,
+
   "@media (max-width: 1000px)": {
-    height: "calc(100dvh - 68px)",
     paddingX: "4px",
     paddingBottom: "4px",
   },
+}
+
+export const ContentArea = {
+  flex: "1 1 0",
+  minWidth: 0,
+  minHeight: 0,
+  display: "flex",
+  flexDirection: "column",
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,8 +12,10 @@ import { cookieToInitialState } from "wagmi"
 
 import {
   BackgroundContainer,
+  ContentArea,
   ContentContainer,
   PageContainer,
+  RootScaffold,
 } from "@/app/[locale]/layout-style"
 import initTranslations from "@/app/i18n"
 import Header from "@/components/Header"
@@ -80,21 +82,12 @@ export default async function RootLayout({
                     {/* <PollingRegistration /> */}
                     <ThemeRegistry>
                       <Box sx={BackgroundContainer} />
-                      <Box position="relative">
+                      <Box sx={RootScaffold}>
                         <Header />
                         <Box sx={PageContainer}>
                           <Box sx={ContentContainer}>
                             <Sidebar />
-                            <Box
-                              width="calc(100vw - 267px)"
-                              sx={{
-                                "@media (max-width: 1000px)": {
-                                  width: "100%",
-                                },
-                              }}
-                            >
-                              {children}
-                            </Box>
+                            <Box sx={ContentArea}>{children}</Box>
                             <Suspense>
                               <HotjarConsent />
                             </Suspense>

--- a/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/LenderActiveMarketsTables/index.tsx
+++ b/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/LenderActiveMarketsTables/index.tsx
@@ -29,7 +29,6 @@ import {
   tokenAmountComparator,
   typeComparator,
 } from "@/utils/comparators"
-import { pageCalcHeights } from "@/utils/constants"
 import {
   buildMarketHref,
   formatBps,
@@ -370,7 +369,8 @@ export const LenderActiveMarketsTables = ({
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: `calc(100vh - ${pageCalcHeights.dashboard})`,
+        flex: "1 1 0",
+        minHeight: 0,
         width: "100%",
         overflow: "auto",
         overflowY: "auto",

--- a/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/LenderTerminatedMarketsTables/index.tsx
+++ b/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/LenderTerminatedMarketsTables/index.tsx
@@ -24,7 +24,6 @@ import { useAppDispatch, useAppSelector } from "@/store/hooks"
 import { setScrollTarget } from "@/store/slices/lenderDashboardSlice/lenderDashboardSlice"
 import { COLORS } from "@/theme/colors"
 import { statusComparator, tokenAmountComparator } from "@/utils/comparators"
-import { pageCalcHeights } from "@/utils/constants"
 import {
   buildMarketHref,
   formatSecsToHours,
@@ -307,7 +306,8 @@ export const LenderTerminatedMarketsTables = ({
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: `calc(100vh - ${pageCalcHeights.dashboard})`,
+        flex: "1 1 0",
+        minHeight: 0,
         width: "100%",
         overflow: "auto",
         overflowY: "auto",

--- a/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/OtherMarketsTables/index.tsx
+++ b/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/OtherMarketsTables/index.tsx
@@ -39,7 +39,6 @@ import {
   tokenAmountComparator,
   typeComparator,
 } from "@/utils/comparators"
-import { pageCalcHeights } from "@/utils/constants"
 import {
   buildMarketHref,
   formatBps,
@@ -427,7 +426,8 @@ export const OtherMarketsTables = ({
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: `calc(100vh - ${pageCalcHeights.dashboard})`,
+        flex: "1 1 0",
+        minHeight: 0,
         width: "100%",
         overflow: "auto",
         overflowY: "auto",

--- a/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/style.ts
+++ b/src/app/[locale]/lender/components/MarketsSection/components/MarketsTables/style.ts
@@ -6,7 +6,7 @@ export const DataGridSx = {
   overflow: "visible",
   height: "auto !important",
   minHeight: DATA_GRID_MIN_HEIGHT,
-  maxWidth: "calc(100vw - 267px)",
+  maxWidth: "100%",
   padding: "0 16px",
   "& .MuiDataGrid-main": {
     overflow: "visible",
@@ -26,6 +26,12 @@ export const DataGridSx = {
   "& .MuiDataGrid-virtualScrollerRenderZone": {
     position: "static !important" as const,
     transform: "none !important",
+  },
+  "& .MuiDataGrid-scrollbar": {
+    display: "none",
+  },
+  "& .MuiDataGrid-scrollbarFiller": {
+    display: "none",
   },
   "& .MuiDataGrid-columnHeaders": {
     position: "sticky",

--- a/src/app/[locale]/lender/components/MarketsSection/index.tsx
+++ b/src/app/[locale]/lender/components/MarketsSection/index.tsx
@@ -382,12 +382,21 @@ export const MarketsSection = () => {
     )
 
   return (
-    <Box sx={{ width: "100%" }}>
+    <Box
+      sx={{
+        width: "100%",
+        flex: "1 1 0",
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       {!isMobile && (
         <Box
           sx={{
             display: "flex",
             flexDirection: "column",
+            flexShrink: 0,
           }}
         >
           <Box

--- a/src/app/[locale]/lender/page.tsx
+++ b/src/app/[locale]/lender/page.tsx
@@ -9,14 +9,22 @@ export default function Lender() {
   return (
     <Box
       sx={{
-        minHeight: { xs: "calc(100dvh - 64px)", md: "auto" },
+        flex: "1 1 0",
+        minHeight: 0,
+        minWidth: 0,
         display: "flex",
         flexDirection: "column",
         paddingTop: { xs: "0px", md: "32px" },
-        overflow: "hidden",
       }}
     >
-      <Box sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          flex: "1 1 0",
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
         <MarketsSection />
       </Box>
       <Footer showFooter={false} />

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -27,9 +27,10 @@ export const Sidebar = () => {
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: "calc(100vh - 82px)",
+        flex: "0 0 267px",
         minWidth: "267px",
         width: "267px",
+        minHeight: 0,
         borderRight: `1px solid ${COLORS.blackRock006}`,
         overflow: "hidden",
         overflowY: "auto",

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -1301,6 +1301,8 @@ export const theme = createTheme({
           border: "none",
           boxShadow: "none",
           padding: 0,
+          minWidth: "0 !important",
+          width: "100%",
         },
       },
     },


### PR DESCRIPTION
- emoved the root 100vw layout issue that caused page-level horizontal scroll
- updated the dashboard layout so market tables resize/transition correctly
- hid extra MUI DataGrid scrollbar tracks in dashboard market tables