### PR TITLE
feat: legal name to deposit modal

### DIFF
--- a/src/app/[locale]/lender/market/[address]/components/Modals/DepositModal/index.tsx
+++ b/src/app/[locale]/lender/market/[address]/components/Modals/DepositModal/index.tsx
@@ -18,6 +18,7 @@ import { LoadingModal } from "@/app/[locale]/borrower/market/[address]/component
 import { SuccessModal } from "@/app/[locale]/borrower/market/[address]/components/Modals/FinalModals/SuccessModal"
 import { useApprovalModal } from "@/app/[locale]/borrower/market/[address]/components/Modals/hooks/useApprovalModal"
 import { useApprove } from "@/app/[locale]/borrower/market/[address]/hooks/useGetApproval"
+import { useGetBorrowerProfile } from "@/app/[locale]/lender/profile/hooks/useGetBorrowerProfile"
 import Alert from "@/assets/icons/circledAlert_icon.svg"
 import Clock from "@/assets/icons/clock_icon.svg"
 import { DepositAlert } from "@/components/DepositAlert"
@@ -38,6 +39,75 @@ import { formatTokenWithCommas } from "@/utils/formatters"
 import { DepositModalProps } from "./interface"
 import { useDeposit } from "../../../hooks/useDeposit"
 
+type BorrowerIdentityDisclosureProps = {
+  legalName: string | undefined
+  alias: string | undefined
+}
+
+const BorrowerIdentityDisclosure = ({
+  legalName,
+  alias,
+}: BorrowerIdentityDisclosureProps) => {
+  const { t } = useTranslation()
+
+  if (!legalName) return null
+
+  const items = [
+    {
+      label: t("borrowerProfile.profile.overallInfo.name"),
+      value: legalName,
+    },
+    ...(alias
+      ? [
+          {
+            label: t("borrowerProfile.profile.overallInfo.alias"),
+            value: alias,
+          },
+        ]
+      : []),
+  ]
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        padding: { xs: "0 20px", md: "0 24px" },
+        marginTop: "auto",
+        marginBottom: "12px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+      }}
+    >
+      {items.map(({ label, value }) => (
+        <Box
+          key={label}
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: "12px",
+          }}
+        >
+          <Typography
+            variant="text3"
+            color={COLORS.santasGrey}
+            sx={{ flexShrink: 0 }}
+          >
+            {label}:
+          </Typography>
+          <Typography
+            variant="text3"
+            sx={{ textAlign: "right", overflowWrap: "anywhere" }}
+          >
+            {value}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
 export const DepositModal = ({
   marketAccount,
   isMobileOpen,
@@ -49,6 +119,20 @@ export const DepositModal = ({
   const { getTxUrl } = useBlockExplorer()
 
   const { market } = marketAccount
+
+  const { data: borrowerProfile } = useGetBorrowerProfile(
+    market.chainId,
+    market.borrower as `0x${string}`,
+  )
+
+  const borrowerLegalName = borrowerProfile?.name?.trim()
+  const borrowerAlias = borrowerProfile?.alias?.trim()
+  const displayedBorrowerAlias =
+    borrowerLegalName &&
+    borrowerAlias &&
+    borrowerAlias.toLowerCase() !== borrowerLegalName.toLowerCase()
+      ? borrowerAlias
+      : undefined
 
   const [amount, setAmount] = useState("")
 
@@ -158,6 +242,7 @@ export const DepositModal = ({
     isUSDTLikeToken(market.underlyingToken.address)
 
   const disableApprove =
+    !borrowerLegalName ||
     market.isClosed ||
     depositTokenAmount.raw.isZero() ||
     depositTokenAmount.raw.gt(market.maximumDeposit.raw) ||
@@ -166,6 +251,7 @@ export const DepositModal = ({
     !Signer.isSigner(market.provider)
 
   const disableDeposit =
+    !borrowerLegalName ||
     !!depositError ||
     market.isClosed ||
     depositTokenAmount.raw.isZero() ||
@@ -487,6 +573,13 @@ export const DepositModal = ({
             />
           )}
 
+          {showForm && (
+            <BorrowerIdentityDisclosure
+              legalName={borrowerLegalName}
+              alias={displayedBorrowerAlias}
+            />
+          )}
+
           <TxModalFooter
             mainBtnText={t("lenderMarketDetails.transactions.deposit.button")}
             secondBtnText={
@@ -798,6 +891,13 @@ export const DepositModal = ({
               type="etherscan"
               linkValue={getTxUrl(txHash as string)}
               groupSX={{ padding: "8px", marginBottom: "8px" }}
+            />
+          )}
+
+          {showForm && (
+            <BorrowerIdentityDisclosure
+              legalName={borrowerLegalName}
+              alias={displayedBorrowerAlias}
             />
           )}
 


### PR DESCRIPTION
ticket: [781](https://github.com/wildcat-finance/product/issues/781)

from ticket:

Lenders must see the borrower's legal name, and the alias if one is in use, at the moment of deposit so that no lender can argue they did not know the legal identity behind the market.

The disclosure must appear in the Deposit confirmation flow itself, not only on the separate "About Borrower" page, because the deposit modal is the point of commitment.