### PR TITLE
fix: unwrap dust max

### DIFF
--- a/src/components/WrapDebtToken/WrapperSection/index.tsx
+++ b/src/components/WrapDebtToken/WrapperSection/index.tsx
@@ -50,6 +50,7 @@ import { lh, pxToRem } from "@/theme/units"
 import { isUSDTLikeToken } from "@/utils/constants"
 import { formatTokenWithCommas } from "@/utils/formatters"
 
+import { getWrapperTransactionMethod } from "./transaction"
 import { ErrorWrapperAlert } from "../ErrorWrapperAlert"
 import { SuccessWrapperModal } from "../SuccessWrapperModal"
 import { WrapperExchangeBanner } from "../WrapperExchangeBanner"
@@ -287,6 +288,10 @@ export const WrapperSection = ({
     maxSharesFromBalance,
   ])
 
+  // Max unwraps redeem exact shares so preview rounding cannot strand dust.
+  const isMaxAssetUnwrap = !isWrapTab && isAssetsInput && !!exactAmount
+  const maxRedeemAmount = isMaxAssetUnwrap ? limits?.maxRedeem : undefined
+
   const maxActionLabel = React.useMemo(() => {
     if (isWrapTab) return isAssetsInput ? "deposit" : "mint"
     return isAssetsInput ? "withdraw" : "redeem"
@@ -377,6 +382,7 @@ export const WrapperSection = ({
     isInputZero ||
     !!helperText ||
     missingPreview ||
+    (isMaxAssetUnwrap && !maxRedeemAmount) ||
     (needsApproval && !safeConnected)
 
   const inputLabel = React.useMemo(() => {
@@ -567,6 +573,15 @@ export const WrapperSection = ({
         )
       }
       if (!inputAmount) throw new Error("No input amount")
+      if (isMaxAssetUnwrap && !maxRedeemAmount) {
+        throw new Error("No max redeem amount")
+      }
+      const transactionMethod = getWrapperTransactionMethod({
+        isWrapTab,
+        isAssetsInput,
+        isMaxAssetUnwrap,
+      })
+      const transactionAmount = maxRedeemAmount ?? inputAmount
 
       if (safeConnected) {
         if (!sdk) throw new Error("No Safe SDK")
@@ -597,14 +612,16 @@ export const WrapperSection = ({
           })
         }
 
-        if (isWrapTab && isAssetsInput) {
-          txs.push(wrapper.populateDeposit(inputAmount, address)) // market → share
-        } else if (isWrapTab && !isAssetsInput) {
-          txs.push(wrapper.populateMint(inputAmount, address)) // share → market (exact out)
-        } else if (!isWrapTab && isAssetsInput) {
-          txs.push(wrapper.populateWithdraw(inputAmount, address, address)) // market → share (exact out)
+        if (transactionMethod === "deposit") {
+          txs.push(wrapper.populateDeposit(transactionAmount, address)) // market → share
+        } else if (transactionMethod === "mint") {
+          txs.push(wrapper.populateMint(transactionAmount, address)) // share → market (exact out)
+        } else if (transactionMethod === "withdraw") {
+          txs.push(
+            wrapper.populateWithdraw(transactionAmount, address, address),
+          ) // market → share (exact out)
         } else {
-          txs.push(wrapper.populateRedeem(inputAmount, address, address)) // share → market
+          txs.push(wrapper.populateRedeem(transactionAmount, address, address)) // share → market
         }
 
         const { safeTxHash } = await sdk.txs.send({ txs })
@@ -613,25 +630,25 @@ export const WrapperSection = ({
         return hash
       }
 
-      if (isWrapTab && isAssetsInput) {
-        const tx = await wrapper.deposit(inputAmount, address)
+      if (transactionMethod === "deposit") {
+        const tx = await wrapper.deposit(transactionAmount, address)
         setTxHash(tx.hash)
         await tx.wait()
         return tx.hash
       }
-      if (isWrapTab && !isAssetsInput) {
-        const tx = await wrapper.mint(inputAmount, address)
+      if (transactionMethod === "mint") {
+        const tx = await wrapper.mint(transactionAmount, address)
         setTxHash(tx.hash)
         await tx.wait()
         return tx.hash
       }
-      if (!isWrapTab && isAssetsInput) {
-        const tx = await wrapper.withdraw(inputAmount, address, address)
+      if (transactionMethod === "withdraw") {
+        const tx = await wrapper.withdraw(transactionAmount, address, address)
         setTxHash(tx.hash)
         await tx.wait()
         return tx.hash
       }
-      const tx = await wrapper.redeem(inputAmount, address, address)
+      const tx = await wrapper.redeem(transactionAmount, address, address)
       setTxHash(tx.hash)
       await tx.wait()
       return tx.hash

--- a/src/components/WrapDebtToken/WrapperSection/index.tsx
+++ b/src/components/WrapDebtToken/WrapperSection/index.tsx
@@ -125,6 +125,7 @@ export const WrapperSection = ({
 
   const [unit, setUnit] = React.useState<AmountUnit>(AmountUnit.ASSETS)
   const [amount, setAmount] = React.useState<string>("")
+  const [exactAmount, setExactAmount] = React.useState<TokenAmount>()
 
   const [showSuccess, setShowSuccess] = React.useState(false)
   const [showError, setShowError] = React.useState(false)
@@ -180,8 +181,8 @@ export const WrapperSection = ({
       : wrapper.marketToken
 
   const inputAmount = React.useMemo(
-    () => parseAmountSafe(inputToken, amount),
-    [inputToken, amount],
+    () => exactAmount ?? parseAmountSafe(inputToken, amount),
+    [exactAmount, inputToken, amount],
   )
 
   const isInputZero = !inputAmount || (inputAmount && inputAmount.raw.isZero())
@@ -340,7 +341,12 @@ export const WrapperSection = ({
         })}`
       : undefined
 
-  const baseHelperText = maxError || balanceError
+  const tooSmallError =
+    !isInputZero && outputAmount && outputAmount.raw.isZero()
+      ? `Amount is too small to ${isWrapTab ? "wrap" : "unwrap"}`
+      : undefined
+
+  const baseHelperText = maxError || balanceError || tooSmallError
   const helperText = isSubmitTransitioning ? undefined : baseHelperText
 
   const hasPreviewRequired =
@@ -399,6 +405,7 @@ export const WrapperSection = ({
 
   const setMaxAmount = () => {
     if (!maxInputAmount) return
+    setExactAmount(maxInputAmount)
     setAmount(maxInputAmount.format(5))
   }
 
@@ -408,6 +415,7 @@ export const WrapperSection = ({
   ) => {
     dispatch(setActiveTab(newTab))
     setAmount("")
+    setExactAmount(undefined)
     setIsSubmitTransitioning(false)
     setSuccessSnapshot(null)
     setShowError(false)
@@ -421,6 +429,7 @@ export const WrapperSection = ({
   ) => {
     setUnit(checked ? AmountUnit.SHARES : AmountUnit.ASSETS)
     setAmount("")
+    setExactAmount(undefined)
     setIsSubmitTransitioning(false)
     setSuccessSnapshot(null)
     setShowError(false)
@@ -431,6 +440,7 @@ export const WrapperSection = ({
   const handleClose = () => {
     setShowSuccess(false)
     setAmount("")
+    setExactAmount(undefined)
     setIsSubmitTransitioning(false)
     setSuccessSnapshot(null)
   }
@@ -657,6 +667,7 @@ export const WrapperSection = ({
         ),
       })
       setAmount("")
+      setExactAmount(undefined)
       setShowSuccess(true)
     },
     onError: (error: Error) => {
@@ -853,9 +864,10 @@ export const WrapperSection = ({
 
                 <NumberTextField
                   value={amount}
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setExactAmount(undefined)
                     setAmount(event.target.value)
-                  }
+                  }}
                   size="medium"
                   label="Amount"
                   error={!!helperText}

--- a/src/components/WrapDebtToken/WrapperSection/transaction.test.ts
+++ b/src/components/WrapDebtToken/WrapperSection/transaction.test.ts
@@ -1,0 +1,22 @@
+import { getWrapperTransactionMethod } from "./transaction"
+
+describe("getWrapperTransactionMethod", () => {
+  it.each([
+    [true, true, false, "deposit"],
+    [true, false, false, "mint"],
+    [false, true, false, "withdraw"],
+    [false, true, true, "redeem"],
+    [false, false, false, "redeem"],
+  ])(
+    "selects %s/%s/max=%s as %s",
+    (isWrapTab, isAssetsInput, isMaxAssetUnwrap, expected) => {
+      expect(
+        getWrapperTransactionMethod({
+          isWrapTab,
+          isAssetsInput,
+          isMaxAssetUnwrap,
+        }),
+      ).toBe(expected)
+    },
+  )
+})

--- a/src/components/WrapDebtToken/WrapperSection/transaction.ts
+++ b/src/components/WrapDebtToken/WrapperSection/transaction.ts
@@ -1,0 +1,19 @@
+export type WrapperTransactionMethod =
+  | "deposit"
+  | "mint"
+  | "withdraw"
+  | "redeem"
+
+export const getWrapperTransactionMethod = ({
+  isWrapTab,
+  isAssetsInput,
+  isMaxAssetUnwrap,
+}: {
+  isWrapTab: boolean
+  isAssetsInput: boolean
+  isMaxAssetUnwrap: boolean
+}): WrapperTransactionMethod => {
+  if (isWrapTab) return isAssetsInput ? "deposit" : "mint"
+  if (isMaxAssetUnwrap) return "redeem"
+  return isAssetsInput ? "withdraw" : "redeem"
+}

--- a/src/hooks/wrapper/useAdoptionData.ts
+++ b/src/hooks/wrapper/useAdoptionData.ts
@@ -12,6 +12,14 @@ export type AdoptionData = {
 }
 
 /**
+ * Values below this are dust: they render as "0" everywhere, so counting them
+ * would report a position of "0 tokens" at "100%".
+ */
+const DUST_FLOOR = 0.00001
+
+const ignoreDust = (value: number) => (value < DUST_FLOOR ? 0 : value)
+
+/**
  fetches adoption data for the wrapper
  *
  * - lender: personal balances. Shares are converted to their underlying
@@ -57,8 +65,8 @@ export const useAdoptionData = (
         return {
           originalAmount: unwrapped,
           wrappedAmount: totalAssets,
-          originalAssetValue: unwrappedFloat,
-          wrappedAssetValue: wrappedFloat,
+          originalAssetValue: ignoreDust(unwrappedFloat),
+          wrappedAssetValue: ignoreDust(wrappedFloat),
         }
       }
 
@@ -87,8 +95,8 @@ export const useAdoptionData = (
       return {
         originalAmount: marketBalance,
         wrappedAmount: shareBalance,
-        originalAssetValue: marketFloat,
-        wrappedAssetValue: sharesAsAssetsFloat,
+        originalAssetValue: ignoreDust(marketFloat),
+        wrappedAssetValue: ignoreDust(sharesAsAssetsFloat),
       }
     },
     refetchOnMount: false,


### PR DESCRIPTION
task: [User can not unwrap all wrapped tokens? #798](https://github.com/wildcat-finance/product/issues/798)
deploy: https://wildcat-app-v2-git-fix-unwrap-dust-max-the-wildcat-protocol.vercel.app/lender

the **Max** button was rounding the amount down to 5 decimal places. because of that, “withdraw all” was actually leaving a tiny balance behind.

it was then impossible to withdraw that remainder: **Max** would set the amount to `0`, leaving the button disabled, and the value was too small to enter manually.

**what changed**

**Max** now uses the exact balance. the UI still displays 5 decimal places, but the transaction receives the full precise amount.

**how it works now**

* “withdraw all” actually withdraws everything, so no remainder is left behind
* any existing remainder can now be withdrawn using **Max**
* if the remainder is so small that the contract cannot unwrap it, we show **“Amount is too small to unwrap”** instead of silently disabling the button
* the status no longer shows **“0 tokens, but 100% wrapped”** — amounts that small are now treated as zero