### PR TITLE
sdk 3.1.17 integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/humanize-duration": "3.27.4",
         "@types/react-scroll": "1.8.10",
         "@types/redux-mock-store": "1.0.6",
-        "@wildcatfi/wildcat-sdk": "3.1.4-beta.4",
+        "@wildcatfi/wildcat-sdk": "3.1.17",
         "base64-arraybuffer": "1.0.2",
         "classnames": "2.5.1",
         "dayjs": "1.11.10",
@@ -18005,9 +18005,9 @@
       }
     },
     "node_modules/@wildcatfi/wildcat-sdk": {
-      "version": "3.1.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wildcatfi/wildcat-sdk/-/wildcat-sdk-3.1.4-beta.4.tgz",
-      "integrity": "sha512-38M+YNrze7pznFuxMuxGQ7te4OeeA78c6M3Yc/TZQBtWKJDc6WEVNNk09KiofcFAkbogHYTapXMNnsb2qIta1Q==",
+      "version": "3.1.17",
+      "resolved": "https://registry.npmjs.org/@wildcatfi/wildcat-sdk/-/wildcat-sdk-3.1.17.tgz",
+      "integrity": "sha512-WS8yE+vLF1BVvex0y2WJ5hRUlgs04LUUral1iRheuMIfW6pVLt9hQJDtcSKvGO5FwssNoQ2QXhR3FpUMFZu92w==",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.8.6",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/humanize-duration": "3.27.4",
     "@types/react-scroll": "1.8.10",
     "@types/redux-mock-store": "1.0.6",
-    "@wildcatfi/wildcat-sdk": "3.1.4-beta.4",
+    "@wildcatfi/wildcat-sdk": "3.1.17",
     "base64-arraybuffer": "1.0.2",
     "classnames": "2.5.1",
     "dayjs": "1.11.10",

--- a/src/lib/protocol-stats/subgraph.ts
+++ b/src/lib/protocol-stats/subgraph.ts
@@ -1,8 +1,8 @@
 export const ETHEREUM_MAINNET_SUBGRAPH_URL =
-  "https://api.goldsky.com/api/public/project_cmheai1ym00jyx7p27qn46qtm/subgraphs/mainnet/v2.0.26/gn"
+  "https://api.goldsky.com/api/public/project_cmheai1ym00jyx7p27qn46qtm/subgraphs/mainnet/v2.0.30/gn"
 
 export const PLASMA_MAINNET_SUBGRAPH_URL =
-  "https://api.goldsky.com/api/public/project_cmheai1ym00jyx7p27qn46qtm/subgraphs/plasma-mainnet/v2.0.22/gn"
+  "https://api.goldsky.com/api/public/project_cmheai1ym00jyx7p27qn46qtm/subgraphs/plasma-mainnet/v2.0.30/gn"
 
 export async function querySubgraph<T>(url: string, query: string): Promise<T> {
   const res = await fetch(url, {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -86,6 +86,8 @@ export const SDK_ERRORS_MAPPING: SDKErrorsMapping = {
     AprChangeDoesNotMatchProposal:
       "APR change does not match the pending proposal",
     AprChangeNotReady: "APR change is not ready to be applied",
+    AprChangeExpired:
+      "APR reduction proposal has expired; submit a new proposal",
     UnpaidWithdrawalsExist:
       "Unpaid withdrawals must be processed before reducing APR",
   },


### PR DESCRIPTION
## Summary

  - Upgrade @wildcatfi/wildcat-sdk to 3.1.17.
  - Move Mainnet and Plasma analytics queries to subgraph v2.0.30.
  - Handle the new AprChangeExpired SDK status.

  ## Validation

  Typecheck, lint, production build, and 77 unit tests passed.